### PR TITLE
Changes to pass validation

### DIFF
--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -425,7 +425,7 @@ function monitorPage(rpde, pageNumber) {
     }
   });
 
-  setTimeout(x => getRPDE(rpde.next, monitorPage), 5000);
+  setTimeout(x => getRPDE(rpde.next, monitorPage), 200);
 }
 
 function monitorOrdersPage(rpde, pageNumber) {

--- a/packages/openactive-broker-microservice/config/default.json
+++ b/packages/openactive-broker-microservice/config/default.json
@@ -1,7 +1,8 @@
 {
   "microservice": {
     "bookingApiBase": "https://bookingsystemreferenceimplementation.azurewebsites.net/api/openbooking/",
-    "openFeedBase": "https://bookingsystemreferenceimplementation.azurewebsites.net/feeds/"
+    "openFeedBase": "https://bookingsystemreferenceimplementation.azurewebsites.net/feeds/",
+    "pollOrdersBookingFeed": true
   },
   "requestLogging": false
 }

--- a/packages/openactive-integration-tests/package-lock.json
+++ b/packages/openactive-integration-tests/package-lock.json
@@ -413,11 +413,11 @@
       }
     },
     "@openactive/data-model-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@openactive/data-model-validator/-/data-model-validator-2.0.1.tgz",
-      "integrity": "sha512-j+tfryBaKlfeEC3p5Wmz2iAuPOABhg/g2DF2lEUkqAtsTI1iNnC3SY5/IHTPzJrWTW7KNukIGAKeWCU1bsPvXw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@openactive/data-model-validator/-/data-model-validator-2.0.12.tgz",
+      "integrity": "sha512-BWUfZ41BZXqG5ui3Vj3sNChnqs7nuZHl0Hlx7/1cUzeBfYHpeNCISaH65GxSeUSYVQz2sJoi2GrynCtqANr10A==",
       "requires": {
-        "@openactive/data-models": "^2.0.14",
+        "@openactive/data-models": "^2.0.43",
         "axios": "^0.18.0",
         "currency-codes": "^1.5.1",
         "jsonpath": "^1.0.2",
@@ -450,9 +450,9 @@
       }
     },
     "@openactive/data-models": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/@openactive/data-models/-/data-models-2.0.51.tgz",
-      "integrity": "sha512-J7S8x3MVt/j1aWBuCyDdY5ocirlWStzVvGhLKrMYwyZRezTTQ9GIibNqCnY2zn83zuymmvkUq1J3GSNZgGFmVw=="
+      "version": "2.0.63",
+      "resolved": "https://registry.npmjs.org/@openactive/data-models/-/data-models-2.0.63.tgz",
+      "integrity": "sha512-KLNvpXSyAEv1Qf5C9ACKifqAY5D5kx4K6pDRtvyBb4kS7DD/Kn2KEkbQx/imBUpPDlYTDbXdPNA4xMg6Q8vDOQ=="
     },
     "@types/babel__core": {
       "version": "7.1.3",
@@ -3574,9 +3574,9 @@
       }
     },
     "luxon": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.21.3.tgz",
-      "integrity": "sha512-lLRwNcNnkZLuv13A1FUuZRZmTWF7ro2ricYvb0L9cvBYHPvZhQdKwrYnZzi103D2XKmlVmxWpdn2wfIiOt2YEw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.22.0.tgz",
+      "integrity": "sha512-3sLvlfbFo+AxVEY3IqxymbumtnlgBwjDExxK60W3d+trrUzErNAz/PfvPT+mva+vEUrdIodeCOs7fB6zHtRSrw==",
       "optional": true
     },
     "make-dir": {

--- a/packages/openactive-integration-tests/package-lock.json
+++ b/packages/openactive-integration-tests/package-lock.json
@@ -450,9 +450,9 @@
       }
     },
     "@openactive/data-models": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@openactive/data-models/-/data-models-2.0.19.tgz",
-      "integrity": "sha512-wsTlP+J0xGkHhieoWUDtdpY7QRSzKLMY3PY0AmpGVzWdnDjD2PNbtWuqZaDJm/PTA/m9wvUVkbf3V3DSCcbXcg=="
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/@openactive/data-models/-/data-models-2.0.51.tgz",
+      "integrity": "sha512-J7S8x3MVt/j1aWBuCyDdY5ocirlWStzVvGhLKrMYwyZRezTTQ9GIibNqCnY2zn83zuymmvkUq1J3GSNZgGFmVw=="
     },
     "@types/babel__core": {
       "version": "7.1.3",

--- a/packages/openactive-integration-tests/package.json
+++ b/packages/openactive-integration-tests/package.json
@@ -10,8 +10,8 @@
   "author": "OpenActive Community <hello@openactive.io>",
   "license": "MIT",
   "dependencies": {
-    "@openactive/data-model-validator": "^2.0.1",
-    "@openactive/data-models": "^2.0.51",
+    "@openactive/data-model-validator": "^2.0.12",
+    "@openactive/data-models": "^2.0.63",
     "axios": "^0.19.0",
     "config": "^3.2.4",
     "fs-extra": "^7.0.1",

--- a/packages/openactive-integration-tests/package.json
+++ b/packages/openactive-integration-tests/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@openactive/data-model-validator": "^2.0.1",
-    "@openactive/data-models": "^2.0.19",
+    "@openactive/data-models": "^2.0.51",
     "axios": "^0.19.0",
     "config": "^3.2.4",
     "fs-extra": "^7.0.1",

--- a/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-failure/book-shared.js
+++ b/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-failure/book-shared.js
@@ -210,10 +210,10 @@ function performTests(dataItem) {
       });
     });
 
-    it("Result from B should OrderConfirmed orderItemStatus", async function() {
+    it("Result from B should OrderItemConfirmed orderItemStatus", async function() {
       return expect(bResponse).to.have.json(
         "orderedItem[0].orderItemStatus",
-        "https://openactive.io/OrderConfirmed"
+        "https://openactive.io/OrderItemConfirmed"
       );
     });
 
@@ -270,7 +270,10 @@ function performTests(dataItem) {
     sharedValidationTests.shouldBeValidResponse(
       () => ordersFeedUpdate.body.data,
       "Orders feed",
-      logger
+      logger, 
+      {
+        validationMode: "OrdersFeed",
+      }
     );
   });
 }

--- a/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-success/book-shared.js
+++ b/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-success/book-shared.js
@@ -211,10 +211,10 @@ function performTests(dataItem) {
       });
     });
 
-    it("Result from B should OrderConfirmed orderItemStatus", async function() {
+    it("Result from B should OrderItemConfirmed orderItemStatus", async function() {
       return expect(bResponse).to.have.json(
         "orderedItem[0].orderItemStatus",
-        "https://openactive.io/OrderConfirmed"
+        "https://openactive.io/OrderItemConfirmed"
       );
     });
 
@@ -266,7 +266,10 @@ function performTests(dataItem) {
     sharedValidationTests.shouldBeValidResponse(
       () => ordersFeedUpdate.body.data,
       "Orders feed",
-      logger
+      logger, 
+      {
+        validationMode: "OrdersFeed",
+      }
     );
   });
 }

--- a/packages/openactive-integration-tests/test/shared-behaviours/validation.js
+++ b/packages/openactive-integration-tests/test/shared-behaviours/validation.js
@@ -6,8 +6,14 @@ function shouldBeValidResponse(getter, name, logger, options = {}) {
   let doValidate = async () => {
     if (results) return results;
 
+    let optionsWithRemoteJson = Object.assign({  
+      loadRemoteJson: true,
+      remoteJsonCachePath: '/tmp',
+      remoteJsonCacheTimeToLive: 3600
+    }, options);
+
     let value = getter();
-    results = await validate(value, options);
+    results = await validate(value, optionsWithRemoteJson);
     return results;
   };
 

--- a/packages/openactive-integration-tests/test/templates/b-req.json
+++ b/packages/openactive-integration-tests/test/templates/b-req.json
@@ -34,6 +34,7 @@
   "orderedItem": [
     {
       "@type": "OrderItem",
+      "position": 0,
       "acceptedOffer": {
         "@type": "Offer",
         "@id": "{{& offerId}}"

--- a/packages/openactive-integration-tests/test/templates/c1-req.json
+++ b/packages/openactive-integration-tests/test/templates/c1-req.json
@@ -27,6 +27,7 @@
   "orderedItem": [
     {
       "@type": "OrderItem",
+      "position": 0,
       "acceptedOffer": {
         "@type": "Offer",
         "@id": "{{& offerId}}"

--- a/packages/openactive-integration-tests/test/templates/c2-req.json
+++ b/packages/openactive-integration-tests/test/templates/c2-req.json
@@ -34,6 +34,7 @@
   "orderedItem": [
     {
       "@type": "OrderItem",
+      "position": 0,
       "acceptedOffer": {
         "@type": "Offer",
         "@id": "{{& offerId}}"


### PR DESCRIPTION
@ylt so the live reference implementation now passes validation against the latest `data-models` using the `data-model-validator`. I had to fix some minor bugs in this test suite to get them to pass (see this PR).

Rather than attempting to merge these in to your work, as I know you're doing some refactoring here, I've left this as a PR just so you can see the fixes.

Would you be able to just port these over to your new refactored code? You should see that all validation tests now pass.

Please do check out the results of C1, as it looks like the validation isn't running properly for that for some reason, but you may have already fixed this in your refactor?