### PR TITLE
Add validation error handling

### DIFF
--- a/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-failure/book-shared.js
+++ b/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-failure/book-shared.js
@@ -66,7 +66,7 @@ function performTests(dataItem) {
     });
 
     sharedValidationTests.shouldBeValidResponse(
-      () => state.c1Response.body,
+      () => state.c1Response,
       "C1",
       logger,
       {
@@ -99,7 +99,7 @@ function performTests(dataItem) {
     });
 
     sharedValidationTests.shouldBeValidResponse(
-      () => state.c2Response.body,
+      () => state.c2Response,
       "C2",
       logger,
       {
@@ -139,7 +139,7 @@ function performTests(dataItem) {
     });
 
     sharedValidationTests.shouldBeValidResponse(
-      () => state.bResponse.body,
+      () => state.bResponse,
       "B",
       logger,
       {
@@ -193,7 +193,7 @@ function performTests(dataItem) {
     });
 
     sharedValidationTests.shouldBeValidResponse(
-      () => state.ordersFeedUpdate.body.data,
+      () => state.ordersFeedUpdate,
       "Orders feed",
       logger,
       {

--- a/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-success/book-shared.js
+++ b/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-success/book-shared.js
@@ -66,7 +66,7 @@ function performTests(dataItem) {
       });
     });
 
-    sharedValidationTests.shouldBeValidResponse(() => state.c1Response.body, "C1", logger, {
+    sharedValidationTests.shouldBeValidResponse(() => state.c1Response, "C1", logger, {
         validationMode: "C1Response"
       }
     );
@@ -96,7 +96,7 @@ function performTests(dataItem) {
     });
 
     sharedValidationTests.shouldBeValidResponse(
-      () => state.c2Response.body,
+      () => state.c2Response,
       "C2",
       logger,
       {
@@ -135,7 +135,7 @@ function performTests(dataItem) {
       );
     });
 
-    sharedValidationTests.shouldBeValidResponse(() => state.bResponse.body, "B", logger, {
+    sharedValidationTests.shouldBeValidResponse(() => state.bResponse, "B", logger, {
       validationMode: "BResponse"
     });
   });
@@ -180,7 +180,7 @@ function performTests(dataItem) {
       );
     });
 
-    sharedValidationTests.shouldBeValidResponse(() => state.ordersFeedUpdate.body.data, "Orders feed", logger, {
+    sharedValidationTests.shouldBeValidResponse(() => state.ordersFeedUpdate.body, "Orders feed", logger, {
       validationMode: "OrdersFeed",
     });
   });

--- a/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-success/book-shared.js
+++ b/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-success/book-shared.js
@@ -180,7 +180,7 @@ function performTests(dataItem) {
       );
     });
 
-    sharedValidationTests.shouldBeValidResponse(() => state.ordersFeedUpdate.body, "Orders feed", logger, {
+    sharedValidationTests.shouldBeValidResponse(() => state.ordersFeedUpdate, "Orders feed", logger, {
       validationMode: "OrdersFeed",
     });
   });

--- a/packages/openactive-integration-tests/test/flows/confirm-availability/availability-confirmed/book-shared.js
+++ b/packages/openactive-integration-tests/test/flows/confirm-availability/availability-confirmed/book-shared.js
@@ -69,7 +69,7 @@ function performTests(dataItem) {
     });
 
     sharedValidationTests.shouldBeValidResponse(
-      () => state.c1Response.body,
+      () => state.c1Response,
       "C1",
       logger,
       {

--- a/packages/openactive-integration-tests/test/flows/confirm-availability/no-spaces-available/book-shared.js
+++ b/packages/openactive-integration-tests/test/flows/confirm-availability/no-spaces-available/book-shared.js
@@ -47,7 +47,7 @@ function performTests(dataItem) {
     });
 
     sharedValidationTests.shouldBeValidResponse(
-      () => state.c1Response.body,
+      () => state.c1Response,
       "C1",
       logger,
       {


### PR DESCRIPTION
Implements #32  

Makes the validation deterministically use a "OpenBookingError" if the response code is a non 2xx. Also adds in a custom validation error message in the case that the body is empty (and thus nothing to validate).

```
• C2
    ❌️ Server returned an error 500 (Internal Server Error) with an empty body.
    ❌️ should return 200 on success
    ❌️ offer should have price of 14.95
```