### PR TITLE
Shared behaviours

### DIFF
--- a/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-failure/book-shared.js
+++ b/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-failure/book-shared.js
@@ -4,6 +4,9 @@ const {Logger} = require("../../../helpers/logger");
 const {RequestState} = require("../../../helpers/request-state");
 const {FlowHelper} = require("../../../helpers/flow-helper");
 const sharedValidationTests = require("../../../shared-behaviours/validation");
+const {C1} = require("../../../shared-behaviours/c1");
+const {C2} = require("../../../shared-behaviours/c2");
+const {B} = require("../../../shared-behaviours/B");
 
 function performTests(dataItem) {
   const { event: testEvent, price, name: eventName } = dataItem;
@@ -32,120 +35,24 @@ function performTests(dataItem) {
   });
 
   describe("C1", function() {
-    beforeAll(async function() {
-      await flow.C1();
-    });
-
-    it("should return 200 on success", function() {
-      expect(state.c1Response).to.have.status(200);
-    });
-
-    it("should return newly created event", function() {
-      expect(state.c1Response).to.have.json(
-        "orderedItem[0].orderedItem.@type",
-        "ScheduledSession"
-      );
-      expect(state.c1Response).to.have.json(
-        "orderedItem[0].orderedItem.superEvent.name",
-        eventName
-      );
-    });
-
-    it("offer should have price of " + price, function() {
-      expect(state.c1Response).to.have.json(
-        "orderedItem[0].acceptedOffer.price",
-        price
-      );
-    });
-
-    it("C1 Order or OrderQuote should have one orderedItem", function() {
-      expect(state.c1Response).to.have.schema("orderedItem", {
-        minItems: 1,
-        maxItems: 1
-      });
-    });
-
-    sharedValidationTests.shouldBeValidResponse(
-      () => state.c1Response,
-      "C1",
-      logger,
-      {
-        validationMode: "C1Response"
-      }
-    );
+    (new C1({state, flow, logger, dataItem}))
+    .beforeSetup()
+    .successChecks()
+    .validationTests();
   });
 
   describe("C2", function() {
-    beforeAll(async function() {
-      await flow.C2();
-    });
-
-    it("should return 200 on success", function() {
-      expect(state.c2Response).to.have.status(200);
-    });
-
-    it("offer should have price of " + price, function() {
-      expect(state.c2Response).to.have.json(
-        "orderedItem[0].acceptedOffer.price",
-        price
-      );
-    });
-
-    it("Order or OrderQuote should have one orderedItem", function() {
-      expect(state.c2Response).to.have.schema("orderedItem", {
-        minItems: 1,
-        maxItems: 1
-      });
-    });
-
-    sharedValidationTests.shouldBeValidResponse(
-      () => state.c2Response,
-      "C2",
-      logger,
-      {
-        validationMode: "C2Response"
-      }
-    );
+    (new C2({state, flow, logger, dataItem}))
+    .beforeSetup()
+    .successChecks()
+    .validationTests();
   });
 
   describe("B", function() {
-    beforeAll(async function() {
-      await flow.B();
-    });
-
-    it("should return 200 on success", function() {
-      expect(state.bResponse).to.have.status(200);
-    });
-
-    it("should have price of " + price, function() {
-      expect(state.bResponse).to.have.json(
-        "orderedItem[0].acceptedOffer.price",
-        price
-      );
-    });
-
-    it("B Order or OrderQuote should have one orderedItem", function() {
-      expect(state.bResponse).to.have.schema("orderedItem", {
-        minItems: 1,
-        maxItems: 1
-      });
-    });
-
-    it("Result from B should OrderItemConfirmed orderItemStatus", function() {
-      expect(state.bResponse).to.have.json(
-        "orderedItem[0].orderItemStatus",
-        "https://openactive.io/OrderItemConfirmed"
-      );
-    });
-
-    sharedValidationTests.shouldBeValidResponse(
-      () => state.bResponse,
-      "B",
-      logger,
-      {
-        validationMode: "BResponse"
-      }
-    );
+    (new B({state, flow, logger, dataItem}))
+    .beforeSetup()
+    .successChecks()
+    .validationTests();
   });
 
   describe("Orders Feed", function() {

--- a/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-success/book-shared.js
+++ b/packages/openactive-integration-tests/test/flows/book-and-cancel/book-and-customer-cancel-success/book-shared.js
@@ -5,6 +5,9 @@ const {Logger} = require("../../../helpers/logger");
 const {RequestState} = require("../../../helpers/request-state");
 const {FlowHelper} = require("../../../helpers/flow-helper");
 const sharedValidationTests = require("../../../shared-behaviours/validation");
+const {C1} = require("../../../shared-behaviours/c1");
+const {C2} = require("../../../shared-behaviours/c2");
+const {B} = require("../../../shared-behaviours/B");
 
 function performTests(dataItem) {
   const { event: testEvent, price, name: eventName } = dataItem;
@@ -33,111 +36,24 @@ function performTests(dataItem) {
   });
 
   describe("C1", function() {
-    beforeAll(async function() {
-      await flow.C1();
-    });
-
-    it("should return 200 on success", function() {
-      expect(state.c1Response).to.have.status(200);
-    });
-
-    it("should return newly created event", function() {
-      expect(state.c1Response).to.have.json(
-        "orderedItem[0].orderedItem.@type",
-        "ScheduledSession"
-      );
-      expect(state.c1Response).to.have.json(
-        "orderedItem[0].orderedItem.superEvent.name",
-        eventName
-      );
-    });
-
-    it("offer should have price of " + price, function() {
-      expect(state.c1Response).to.have.json(
-        "orderedItem[0].acceptedOffer.price",
-        price
-      );
-    });
-
-    it("C1 Order or OrderQuote should have one orderedItem", function() {
-      expect(state.c1Response).to.have.schema("orderedItem", {
-        minItems: 1,
-        maxItems: 1
-      });
-    });
-
-    sharedValidationTests.shouldBeValidResponse(() => state.c1Response, "C1", logger, {
-        validationMode: "C1Response"
-      }
-    );
+    (new C1({state, flow, logger, dataItem}))
+      .beforeSetup()
+      .successChecks()
+      .validationTests();
   });
 
   describe("C2", function() {
-    beforeAll(async function() {
-      await flow.C2();
-    });
-
-    it("should return 200 on success", async function() {
-      expect(state.c2Response).to.have.status(200);
-    });
-
-    it("offer should have price of " + price, async function() {
-      expect(state.c2Response).to.have.json(
-        "orderedItem[0].acceptedOffer.price",
-        price
-      );
-    });
-
-    it("Order or OrderQuote should have one orderedItem", async function() {
-      expect(state.c2Response).to.have.schema("orderedItem", {
-        minItems: 1,
-        maxItems: 1
-      });
-    });
-
-    sharedValidationTests.shouldBeValidResponse(
-      () => state.c2Response,
-      "C2",
-      logger,
-      {
-        validationMode: "C2Response"
-      }
-    );
+    (new C2({state, flow, logger, dataItem}))
+    .beforeSetup()
+    .successChecks()
+    .validationTests();
   });
 
   describe("B", function() {
-    beforeAll(async function() {
-      await flow.B();
-    });
-
-    it("should return 200 on success", function() {
-      expect(state.bResponse).to.have.status(200);
-    });
-
-    it("should have price of " + price, function() {
-      expect(state.bResponse).to.have.json(
-        "orderedItem[0].acceptedOffer.price",
-        price
-      );
-    });
-
-    it("B Order or OrderQuote should have one orderedItem", function() {
-      expect(state.bResponse).to.have.schema("orderedItem", {
-        minItems: 1,
-        maxItems: 1
-      });
-    });
-
-    it("Result from B should OrderItemConfirmed orderItemStatus", function() {
-      expect(state.bResponse).to.have.json(
-        "orderedItem[0].orderItemStatus",
-        "https://openactive.io/OrderItemConfirmed"
-      );
-    });
-
-    sharedValidationTests.shouldBeValidResponse(() => state.bResponse, "B", logger, {
-      validationMode: "BResponse"
-    });
+    (new B({state, flow, logger, dataItem}))
+    .beforeSetup()
+    .successChecks()
+    .validationTests();
   });
 
   describe("Orders Feed", function() {

--- a/packages/openactive-integration-tests/test/flows/confirm-availability/availability-confirmed/book-shared.js
+++ b/packages/openactive-integration-tests/test/flows/confirm-availability/availability-confirmed/book-shared.js
@@ -4,8 +4,7 @@ const expect = chakram.expect;
 const {Logger} = require("../../../helpers/logger");
 const {RequestState} = require("../../../helpers/request-state");
 const {FlowHelper} = require("../../../helpers/flow-helper");
-
-const sharedValidationTests = require("../../../shared-behaviours/validation");
+const {C1} = require("../../../shared-behaviours/c1");
 
 function performTests(dataItem) {
   const { event: testEvent, price, name: eventName } = dataItem;
@@ -31,51 +30,10 @@ function performTests(dataItem) {
   });
 
   describe("C1", function() {
-    beforeAll(async function() {
-      await flow.C1();
-    });
-
-    it("should return 200 on success", function() {
-      expect(state.c1Response).to.have.status(200);
-    });
-
-    it("should return newly created event", function() {
-      expect(state.c1Response).to.have.json(
-        "orderedItem[0].orderedItem.@type",
-        "ScheduledSession"
-      );
-      expect(state.c1Response).to.have.json(
-        "orderedItem[0].orderedItem.superEvent.name",
-        eventName
-      );
-    });
-
-    it("offer should have price of " + price, function() {
-      expect(state.c1Response).to.have.json(
-        "orderedItem[0].acceptedOffer.price",
-        price
-      );
-    });
-
-    it("OrderQuote.totalPaymentDue equal to " + price, function() {
-      expect(state.c1Response).to.have.json("totalPaymentDue.price", price);
-    });
-
-    it("C1 Order or OrderQuote should have one orderedItem", function() {
-      expect(state.c1Response).to.have.schema("orderedItem", {
-        minItems: 1,
-        maxItems: 1
-      });
-    });
-
-    sharedValidationTests.shouldBeValidResponse(
-      () => state.c1Response,
-      "C1",
-      logger,
-      {
-        validationMode: "C1Response"
-      }
-    );
+    (new C1({state, flow, logger, dataItem}))
+    .beforeSetup()
+    .successChecks()
+    .validationTests();
   });
 }
 

--- a/packages/openactive-integration-tests/test/shared-behaviours/b.js
+++ b/packages/openactive-integration-tests/test/shared-behaviours/b.js
@@ -1,0 +1,76 @@
+const {expect} = require("chakram");
+const sharedValidationTests = require("./validation");
+
+class B {
+  constructor ({state, flow, logger, dataItem}) {
+    this.state = state;
+    this.flow = flow;
+    this.logger = logger;
+    this.dataItem = dataItem;
+  }
+
+  get testEvent () {
+    return this.dataItem.event;
+  }
+
+  get eventName () {
+    return this.dataItem.name;
+  }
+
+  get price () {
+    return this.dataItem.price;
+  }
+
+  validationTests () {
+    sharedValidationTests.shouldBeValidResponse(
+      () => this.state.bResponse,
+      "B",
+      this.logger,
+      {
+        validationMode: "BResponse",
+      },
+    );
+    return this;
+  }
+
+  beforeSetup () {
+    beforeAll(async () => {
+      await this.flow.B();
+    });
+
+    return this;
+  }
+
+  successChecks () {
+    it("should return 200 on success", () => {
+      expect(this.state.bResponse).to.have.status(200);
+    });
+
+    it("should have price of " + this.price, () => {
+      expect(this.state.bResponse).to.have.json(
+        "orderedItem[0].acceptedOffer.this.price",
+        this.price
+      );
+    });
+
+    it("B Order or OrderQuote should have one orderedItem", () => {
+      expect(this.state.bResponse).to.have.schema("orderedItem", {
+        minItems: 1,
+        maxItems: 1
+      });
+    });
+
+    it("Result from B should OrderItemConfirmed orderItemStatus", () => {
+      expect(this.state.bResponse).to.have.json(
+        "orderedItem[0].orderItemStatus",
+        "https://openactive.io/OrderItemConfirmed"
+      );
+    });
+
+    return this;
+  }
+}
+
+module.exports = {
+  B
+};

--- a/packages/openactive-integration-tests/test/shared-behaviours/c1.js
+++ b/packages/openactive-integration-tests/test/shared-behaviours/c1.js
@@ -1,0 +1,85 @@
+const {expect} = require("chakram");
+const sharedValidationTests = require("./validation");
+
+class C1 {
+  constructor ({state, flow, logger, dataItem}) {
+    this.state = state;
+    this.flow = flow;
+    this.logger = logger;
+    this.dataItem = dataItem;
+  }
+
+  get testEvent () {
+    return this.dataItem.event;
+  }
+
+  get eventName () {
+    return this.dataItem.name;
+  }
+
+  get price () {
+    return this.dataItem.price;
+  }
+
+  validationTests () {
+    sharedValidationTests.shouldBeValidResponse(
+      () => this.state.c1Response,
+      "C1",
+      this.logger,
+      {
+        validationMode: "C1Response",
+      },
+    );
+    return this;
+  }
+
+  beforeSetup () {
+    beforeAll(async () => {
+      await this.flow.C1();
+    });
+    return this;
+  }
+
+  successChecks () {
+    it("should return 200 on success", () => {
+      expect(this.state.c1Response).to.have.status(200);
+    });
+
+    it("should return newly created event", () => {
+      expect(this.state.c1Response).to.have.json(
+        "orderedItem[0].orderedItem.@type",
+        "ScheduledSession",
+      );
+      expect(this.state.c1Response).to.have.json(
+        "orderedItem[0].orderedItem.superEvent.name",
+        this.eventName,
+      );
+    });
+
+    it("offer should have price of " + this.price, () => {
+      expect(this.state.c1Response).to.have.json(
+        "orderedItem[0].acceptedOffer.price",
+        this.price,
+      );
+    });
+
+    it("OrderQuote.totalPaymentDue equal to " + this.price, () => {
+      expect(this.state.c1Response).
+        to.
+        have.
+        json("totalPaymentDue.price", this.price);
+    });
+
+    it("C1 Order or OrderQuote should have one orderedItem", () => {
+      expect(this.state.c1Response).to.have.schema("orderedItem", {
+        minItems: 1,
+        maxItems: 1,
+      });
+    });
+    return this;
+  }
+}
+
+module.exports = {
+  C1
+};

--- a/packages/openactive-integration-tests/test/shared-behaviours/c2.js
+++ b/packages/openactive-integration-tests/test/shared-behaviours/c2.js
@@ -1,0 +1,69 @@
+const {expect} = require("chakram");
+const sharedValidationTests = require("./validation");
+
+class C2 {
+  constructor ({state, flow, logger, dataItem}) {
+    this.state = state;
+    this.flow = flow;
+    this.logger = logger;
+    this.dataItem = dataItem;
+  }
+
+  get testEvent () {
+    return this.dataItem.event;
+  }
+
+  get eventName () {
+    return this.dataItem.name;
+  }
+
+  get price () {
+    return this.dataItem.price;
+  }
+
+  validationTests () {
+    sharedValidationTests.shouldBeValidResponse(
+      () => this.state.c2Response,
+      "C2",
+      this.logger,
+      {
+        validationMode: "C2Response",
+      },
+    );
+    return this;
+  }
+
+  beforeSetup () {
+    beforeAll(async () => {
+      await this.flow.C2();
+    });
+
+    return this;
+  }
+
+  successChecks () {
+    it("should return 200 on success", () => {
+      expect(this.state.c2Response).to.have.status(200);
+    });
+
+    it("offer should have price of " + this.price, () => {
+      expect(this.state.c2Response).to.have.json(
+        "orderedItem[0].acceptedOffer.price",
+        this.price
+      );
+    });
+
+    it("Order or OrderQuote should have one orderedItem", () => {
+      expect(this.state.c2Response).to.have.schema("orderedItem", {
+        minItems: 1,
+        maxItems: 1
+      });
+    });
+
+    return this;
+  }
+}
+
+module.exports = {
+  C2
+};


### PR DESCRIPTION
Point 5 on https://github.com/openactive/openactive-test-suite/issues/34
> "Generalise some of C1, C2 tests etc to provide shared examples that can be reused across shared test suites."