### PR TITLE
Cleaner logging

### DIFF
--- a/packages/openactive-integration-tests/package-lock.json
+++ b/packages/openactive-integration-tests/package-lock.json
@@ -3169,9 +3169,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-globals": {
@@ -3185,9 +3185,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -6767,9 +6767,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "kleur": {
       "version": "3.0.3",

--- a/packages/openactive-integration-tests/package-lock.json
+++ b/packages/openactive-integration-tests/package-lock.json
@@ -3217,10 +3217,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -8128,6 +8127,23 @@
       "requires": {
         "astral-regex": "^1.0.0",
         "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "string.prototype.trimleft": {
@@ -8163,12 +8179,11 @@
       "dev": true
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^5.0.0"
       }
     },
     "strip-bom": {

--- a/packages/openactive-integration-tests/package.json
+++ b/packages/openactive-integration-tests/package.json
@@ -24,6 +24,7 @@
     "moment": "^2.24.0",
     "p-memoize": "^3.1.0",
     "rmfr": "^2.0.0",
+    "strip-ansi": "^6.0.0",
     "sync-request": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/openactive-integration-tests/test/helpers/logger.js
+++ b/packages/openactive-integration-tests/test/helpers/logger.js
@@ -166,6 +166,20 @@ class ReporterLogger extends BaseLogger {
     return this.testName;
   }
 
+  get activeSuites() {
+    let activeSuites = [];
+    for (let log of this.logs) {
+      activeSuites.push(log.ancestorTitles);
+    }
+    activeSuites = _.uniqWith(activeSuites, _.isEqual);
+
+    let active = this.suites.filter(suite => {
+      return _.find(activeSuites, (asuite) => _.isEqual(suite, asuite));
+    });
+
+    return active;
+  }
+
   recordTestResult(stage, data) {
     if (!this.flow[stage]) this.flow[stage] = {};
     if (!this.flow[stage].response) this.flow[stage].response = {};

--- a/packages/openactive-integration-tests/test/helpers/request-helper.js
+++ b/packages/openactive-integration-tests/test/helpers/request-helper.js
@@ -23,18 +23,20 @@ class RequestHelper {
   }
 
   async _request(stage, method, url, params, headers) {
-    let response = await chakram[method.toLowerCase()](url, params, headers);
+    let responsePromise = chakram[method.toLowerCase()](url, params, headers);
 
     this.logger.recordRequestResponse(stage, {
       method: method.toUpperCase(),
       url: url,
       params: params,
       headers: headers
-    }, response);
+    }, responsePromise);
 
     if (params) {
       this.logger.recordRequest(stage, params);
     }
+
+    let response = await responsePromise;
     this.logger.recordResponse(stage, response);
 
     return response;

--- a/packages/openactive-integration-tests/test/report-generator.js
+++ b/packages/openactive-integration-tests/test/report-generator.js
@@ -2,6 +2,7 @@ const chalk = require('chalk');
 const Handlebars = require('handlebars');
 const pMemoize = require('p-memoize');
 const fs = require('fs').promises;
+const stripAnsi = require('strip-ansi');
 
 class ReportGenerator {
   constructor(logger) {
@@ -43,7 +44,7 @@ class ReportGenerator {
     });
 
     Handlebars.registerHelper("firstLine", function(message, options) {
-      return message.split("\n")[0];
+      return stripAnsi(message.split("\n")[0]);
     });
 
     Handlebars.registerHelper("json", function(data, options) {

--- a/packages/openactive-integration-tests/test/report-generator.js
+++ b/packages/openactive-integration-tests/test/report-generator.js
@@ -19,6 +19,12 @@ class ReportGenerator {
       return chalkFn(options.fn(this));
     });
 
+    Handlebars.registerHelper("renderSuiteName", function(suiteName, options) {
+      if (suiteName.length <= 2) return "Test setup";
+
+      return suiteName.slice(2).join(" >> ");
+    });
+
     Handlebars.registerHelper("validationIcon", function(severity, options) {
       switch (severity) {
         case "warning":
@@ -101,7 +107,10 @@ class ReportGenerator {
   async writeMarkdown() {
     let template = await this.getTemplate('report.md');
 
-    let data = template(this.logger);
+    let data = template(this.logger, {
+      allowProtoMethodsByDefault: true,
+      allowProtoPropertiesByDefault: true
+    });
 
     await fs.writeFile(this.logger.markdownPath, data);
   }

--- a/packages/openactive-integration-tests/test/report-templates/report-cli.handlebars
+++ b/packages/openactive-integration-tests/test/report-templates/report-cli.handlebars
@@ -1,6 +1,6 @@
-{{# chalk "bold" }}{{ title }}{{/chalk}}
+{{# chalk "bold" }}{{{ title }}}{{/chalk}}
 
-{{ description }}
+{{{ description }}}
 
 See `{{{ markdownPath }}}` for more detailed info.
 
@@ -18,5 +18,11 @@ See `{{{ markdownPath }}}` for more detailed info.
         {{/each}}
     {{/logsFor}}
 {{/each}}
+
+{{#logsFor null "request"}}
+    {{~# if isPending }}
+*** Pending request: {{stage}} - {{{request.method}}} {{{ request.url }}}
+    {{/if~}}
+{{/logsFor}}
 
 ======

--- a/packages/openactive-integration-tests/test/report-templates/report-cli.handlebars
+++ b/packages/openactive-integration-tests/test/report-templates/report-cli.handlebars
@@ -4,7 +4,7 @@
 
 See `{{{ markdownPath }}}` for more detailed info.
 
-{{#each suites }}
+{{#each activeSuites }}
 {{#each . }}{{# chalk "bold" "yellow" }}>>{{/chalk}} {{# chalk "bold" "green" }}{{{ . }}}{{/chalk}} {{/each}}
     {{#logsFor . "spec"}}
   {{ specIcon spec.status }} {{{firstLine spec.title}}}

--- a/packages/openactive-integration-tests/test/report-templates/report-cli.handlebars
+++ b/packages/openactive-integration-tests/test/report-templates/report-cli.handlebars
@@ -8,6 +8,9 @@ See `{{{ markdownPath }}}` for more detailed info.
 {{#each . }}{{# chalk "bold" "yellow" }}>>{{/chalk}} {{# chalk "bold" "green" }}{{{ . }}}{{/chalk}} {{/each}}
     {{#logsFor . "spec"}}
   {{ specIcon spec.status }} {{{firstLine spec.title}}}
+        {{#each spec.failureMessages}}
+      {{{firstLine . }}}
+        {{/each}}
     {{/logsFor}}
     {{#logsFor . "validations"}}
         {{#each validations }}

--- a/packages/openactive-integration-tests/test/report-templates/report.md.handlebars
+++ b/packages/openactive-integration-tests/test/report-templates/report.md.handlebars
@@ -2,8 +2,8 @@
 
 {{{ description }}}
 
-{{#each suites }}
-## {{#each . }} >> {{{ . }}}{{/each}}
+{{#each activeSuites }}
+## {{{ renderSuiteName . }}}
     {{#logsFor . "request"}}
 ### {{stage}} Request
 {{{request.method}}} {{{ request.url }}}

--- a/packages/openactive-integration-tests/test/report-templates/report.md.handlebars
+++ b/packages/openactive-integration-tests/test/report-templates/report.md.handlebars
@@ -25,10 +25,16 @@ Response status code: {{{ response.status }}} {{{ response.statusMessage}}}. Res
         {{/if}}
     {{/logsFor}}
     {{#logsFor . "spec"}}
-{{#if @first}}### Specs{{/if}}
- * {{ specIcon spec.status }} {{{firstLine spec.title}}}{{/logsFor}}
+{{~#if @first~}}### Specs
+{{/if}}
+ * {{ specIcon spec.status }} {{{firstLine spec.title}}}
+        {{#each spec.failureMessages}}
+    - {{{firstLine . }}}
+        {{/each}}
+    {{/logsFor}}
     {{#logsFor . "validations"}}
-{{#if @first}}### Validations{{/if}}
+{{#if @first~}}### Validations
+{{/if~}}
         {{#each validations }}
  * {{ validationIcon severity }} {{{firstLine message}}}
         {{/each}}

--- a/packages/openactive-integration-tests/test/report-templates/report.md.handlebars
+++ b/packages/openactive-integration-tests/test/report-templates/report.md.handlebars
@@ -12,6 +12,9 @@
 {{{ json request.params }}}
 ```
     {{/if}}
+        {{#if isPending}}
+**Response still pending**
+        {{/if}}
         {{#if response.status}}
 
 ---


### PR DESCRIPTION
Addresses https://github.com/openactive/openactive-test-suite/issues/46

- Cleans out the titles so that the full test path isn't references
- Removes out sections without any info to display
- Renders out errors

Couple of other changes:
- Updated project dependencies to non-vulnerable versions
- ANSI stripping