### PR TITLE
docs: Update to make feature CI mirroring clear

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,21 +2,11 @@
 
 When contributing to this repository, please first discuss the change you wish to make via issue, Slack, or any other method with the owners of this repository before making a change.
 
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+Please note we have a [Code of Conduct](https://openactive.io/public-openactive-w3c/code-of-conduct/), please follow it in all your interactions with the project.
 
 ## Commits
 
 Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages. This makes our commit history easy to understand by humans and by automated tools.
-
-## Pull Request Process
-
-Changes should be made by starting a new branch (from `master`), writing the changes in that branch and then submitting a Pull Request to rebase that branch into `master`.
-
-1. Every Pull Request should solve or partially solve an existing GitHub issue.
-2. For changes to the `openactive-integration-tests` package, run the documentation generator, by running `npm run doc-gen --prefix packages/openactive-integration-tests`.
-3. Ensure that documentation reflects the new changes.
-4. Check that CI tests pass before merging a Pull Request.
-5. Ensure that your Pull Request has at least one approval before merging.
 
 ## Reference Implementation
 
@@ -27,6 +17,16 @@ The CI checks that the Test Suite passes for the reference implementation. There
 - Reference Implementation: The implementation of the feature that's being tested.
 - Test Suite: The test itself.
 
-# Code of Conduct
+Any new feature must be developed in a `feature/*` branch in both reposities, in order for the CI to automatically run both feature branches against each other.
 
-By contributing to this project you agree to follow our [Code of Conduct](https://openactive.io/public-openactive-w3c/code-of-conduct/).
+## Pull Request Process
+
+Changes should be made by starting a new branch (from `master`), writing the changes in that branch and then submitting a Pull Request to rebase that branch into `master`.
+
+For new features, use a `feature/*` branch in this repository that matches a `feature/*` branch in [OpenActive.Server.NET](https://github.com/openactive/OpenActive.Server.NET/).
+
+1. Every Pull Request should solve or partially solve an existing GitHub issue.
+2. For changes to the `openactive-integration-tests` package, run the documentation generator, by running `npm run doc-gen --prefix packages/openactive-integration-tests`.
+3. Ensure that documentation reflects the new changes.
+4. Check that CI tests pass before merging a Pull Request.
+5. Ensure that your Pull Request has at least one approval before merging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Any new feature must be developed in a `feature/*` branch in both reposities, in
 
 Changes should be made by starting a new branch (from `master`), writing the changes in that branch and then submitting a Pull Request to rebase that branch into `master`.
 
-For new features, use a `feature/*` branch in this repository that matches a `feature/*` branch in [OpenActive.Server.NET](https://github.com/openactive/OpenActive.Server.NET/).
+For new features, use a `feature/*` branch in this repository that matches a `feature/*` branch in [OpenActive.Server.NET](https://github.com/openactive/OpenActive.Server.NET/). The OpenActive.Server.NET CI will use the tests in the test-suite branch to test the server's changes.
 
 1. Every Pull Request should solve or partially solve an existing GitHub issue.
 2. For changes to the `openactive-integration-tests` package, run the documentation generator, by running `npm run doc-gen --prefix packages/openactive-integration-tests`.


### PR DESCRIPTION
Improve docs to include `feature/*` branch checking in CI