### PR TITLE
fix: Update to use coverage/ prefix

### DIFF
--- a/.github/workflows/reference-implementation.yml
+++ b/.github/workflows/reference-implementation.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: tests
-    - name: Use matching coverage/ branch ${{ github.head_ref }} in OpenActive.Server.NET
+    - name: Use matching coverage/* branch ${{ github.head_ref }} in OpenActive.Server.NET
       if: ${{ startsWith(github.head_ref, 'coverage/') }}
       run: echo "::set-env name=mirror_ref::${{ github.head_ref }}"
     - name: Checkout OpenActive.Server.NET ${{ env.mirror_ref }}

--- a/.github/workflows/reference-implementation.yml
+++ b/.github/workflows/reference-implementation.yml
@@ -16,8 +16,8 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: tests
-    - name: Use matching feature branch ${{ github.head_ref }} in OpenActive.Server.NET
-      if: ${{ startsWith(github.head_ref, 'feature/') }}
+    - name: Use matching coverage/ branch ${{ github.head_ref }} in OpenActive.Server.NET
+      if: ${{ startsWith(github.head_ref, 'coverage/') }}
       run: echo "::set-env name=mirror_ref::${{ github.head_ref }}"
     - name: Checkout OpenActive.Server.NET ${{ env.mirror_ref }}
       uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,13 @@ The CI checks that the Test Suite passes for the reference implementation. There
 - Reference Implementation: The implementation of the feature that's being tested.
 - Test Suite: The test itself.
 
-Any new feature must be developed in a `feature/*` branch in both reposities, in order for the CI to automatically run both feature branches against each other.
+Any new feature that affects test coverage must be developed in a `coverage/*` branch in both reposities, in order for the CI to automatically run both feature branches against each other.
 
 ## Pull Request Process
 
 Changes should be made by starting a new branch (from `master`), writing the changes in that branch and then submitting a Pull Request to rebase that branch into `master`.
 
-For new features, use a `feature/*` branch in this repository that matches a `feature/*` branch in [OpenActive.Server.NET](https://github.com/openactive/OpenActive.Server.NET/). The OpenActive.Server.NET CI will use the tests in the test-suite branch to test the server's changes.
+For new features that affect test coverage, use a `coverage/*` branch in this repository that matches a `feature/*` branch in [OpenActive.Server.NET](https://github.com/openactive/OpenActive.Server.NET/). The OpenActive.Server.NET CI will use the tests in the test-suite branch to test the server's changes.
 
 1. Every Pull Request should solve or partially solve an existing GitHub issue.
 2. For changes to the `openactive-integration-tests` package, run the documentation generator, by running `npm run doc-gen --prefix packages/openactive-integration-tests`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Any new feature that affects test coverage must be developed in a `coverage/*` b
 
 Changes should be made by starting a new branch (from `master`), writing the changes in that branch and then submitting a Pull Request to rebase that branch into `master`.
 
-For new features that affect test coverage, use a `coverage/*` branch in this repository that matches a `feature/*` branch in [OpenActive.Server.NET](https://github.com/openactive/OpenActive.Server.NET/). The OpenActive.Server.NET CI will use the tests in the test-suite branch to test the server's changes.
+For new features that affect test coverage, use a `coverage/*` branch in this repository that matches a `coverage/*` branch in [OpenActive.Server.NET](https://github.com/openactive/OpenActive.Server.NET/). The OpenActive.Server.NET CI will use the tests in the test-suite branch to test the server's changes.
 
 1. Every Pull Request should solve or partially solve an existing GitHub issue.
 2. For changes to the `openactive-integration-tests` package, run the documentation generator, by running `npm run doc-gen --prefix packages/openactive-integration-tests`.


### PR DESCRIPTION
Use `coverage/` so it doesn't conflict with convention