### PR TITLE
chore: Run static checks on CI

### DIFF
--- a/.github/workflows/reference-implementation.yml
+++ b/.github/workflows/reference-implementation.yml
@@ -51,18 +51,20 @@ jobs:
       run: | 
         npm install --prefix tests/packages/openactive-broker-microservice
         npm install --prefix tests/packages/openactive-integration-tests
+    - name: Run Checks on the Code (Test the Tests!)
+      run: npm test --prefix tests
     - name: Start Broker Microservice
       run: | 
         NODE_CONFIG='{"waitForHarvestCompletion": true, "datasetSiteUrl": "https://localhost:5001/openactive"}' npm start --prefix tests/packages/openactive-broker-microservice &
     - name: Run OpenActive Integration Tests in Random Mode
       run: |
         rm -rf ./tests/packages/openactive-integration-tests/output/
-        NODE_CONFIG='{ "sellers": { "primary": { "@type": "Organization", "@id": "https://localhost:5001/api/identifiers/sellers/0", "requestHeaders": { "X-OpenActive-Test-Client-Id": "test", "X-OpenActive-Test-Seller-Id": "https://localhost:5001/api/identifiers/sellers/0" } }, "secondary": { "@type": "Person", "@id": "https://localhost:5001/api/identifiers/sellers/1" } }, "useRandomOpportunities": true, "generateConformanceCertificate": true, "conformanceCertificateId": "https://openactive.io/openactive-test-suite/example-output/random/certification/" }' npm test --prefix tests/packages/openactive-integration-tests --runInBand -- test/features/
+        NODE_CONFIG='{ "sellers": { "primary": { "@type": "Organization", "@id": "https://localhost:5001/api/identifiers/sellers/0", "requestHeaders": { "X-OpenActive-Test-Client-Id": "test", "X-OpenActive-Test-Seller-Id": "https://localhost:5001/api/identifiers/sellers/0" } }, "secondary": { "@type": "Person", "@id": "https://localhost:5001/api/identifiers/sellers/1" } }, "useRandomOpportunities": true, "generateConformanceCertificate": true, "conformanceCertificateId": "https://openactive.io/openactive-test-suite/example-output/random/certification/" }' npm start --prefix tests/packages/openactive-integration-tests --runInBand -- test/features/
         cp -R ./tests/packages/openactive-integration-tests/output/* ./publish/example-output/random/
     - name: Run OpenActive Integration Tests in Controlled Mode
       run: |
         rm -rf ./tests/packages/openactive-integration-tests/output/
-        NODE_CONFIG='{ "sellers": { "primary": { "@type": "Organization", "@id": "https://localhost:5001/api/identifiers/sellers/0", "requestHeaders": { "X-OpenActive-Test-Client-Id": "test", "X-OpenActive-Test-Seller-Id": "https://localhost:5001/api/identifiers/sellers/0" } }, "secondary": { "@type": "Person", "@id": "https://localhost:5001/api/identifiers/sellers/1" } }, "useRandomOpportunities": false, "generateConformanceCertificate": true, "conformanceCertificateId": "https://openactive.io/openactive-test-suite/example-output/controlled/certification/" }' npm test --prefix tests/packages/openactive-integration-tests --runInBand -- test/features/
+        NODE_CONFIG='{ "sellers": { "primary": { "@type": "Organization", "@id": "https://localhost:5001/api/identifiers/sellers/0", "requestHeaders": { "X-OpenActive-Test-Client-Id": "test", "X-OpenActive-Test-Seller-Id": "https://localhost:5001/api/identifiers/sellers/0" } }, "secondary": { "@type": "Person", "@id": "https://localhost:5001/api/identifiers/sellers/1" } }, "useRandomOpportunities": false, "generateConformanceCertificate": true, "conformanceCertificateId": "https://openactive.io/openactive-test-suite/example-output/controlled/certification/" }' npm start --prefix tests/packages/openactive-integration-tests --runInBand -- test/features/
         cp -R ./tests/packages/openactive-integration-tests/output/* ./publish/example-output/controlled/
     - name: Deploy test output to GitHub Pages (master branch only)
       uses: peaceiris/actions-gh-pages@v3

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ The broker microservice must be running before the test suite is run.
 ### Broker microservice
 ```bash
 cd packages/openactive-broker-microservice
-npm run start
+npm start
 ```
 
 ### Tests
 ```bash
 cd packages/openactive-integration-tests
-npm run test
+npm start
 ```
 
 
@@ -69,7 +69,7 @@ pid=$!
 trap 'err=$?; echo >&2 "Exiting on error $err"; kill $pid; exit $err' ERR
 
 # Run tests
-npm test --prefix packages/openactive-integration-tests
+npm start --prefix packages/openactive-integration-tests
 
 # Kill broker microservice on success
 kill $pid

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "install": "npm install --prefix packages/openactive-broker-microservice && npm install --prefix packages/openactive-integration-tests",
     "prettier": "prettier --check \"packages/**/*.js\" \"packages/**/*.json\"",
     "prettier:write": "prettier --write \"packages/**/*.js\" \"packages/**/*.json\"",
-    "start": "npm start --prefix packages/openactive-broker-microservice",
+    "start": "echo 'Error: please select a package to run and then run it e.g. `npm start --prefix packages/openactive-broker-microservice`' && exit 1",
+    "start-broker": "npm start --prefix packages/openactive-broker-microservice",
+    "start-tests": "npm start --prefix packages/openactive-integration-tests",
     "test": "npm test --prefix packages/openactive-integration-tests",
     "certificate-validator": "npm run certificate-validator --prefix packages/openactive-integration-tests"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "echo 'Error: please select a package to run and then run it e.g. `npm start --prefix packages/openactive-broker-microservice`' && exit 1",
     "start-broker": "npm start --prefix packages/openactive-broker-microservice",
     "start-tests": "npm start --prefix packages/openactive-integration-tests",
-    "test": "npm test --prefix packages/openactive-integration-tests",
+    "test": "npm test --prefix packages/openactive-broker-microservice && npm test --prefix packages/openactive-integration-tests",
     "certificate-validator": "npm run certificate-validator --prefix packages/openactive-integration-tests"
   },
   "dependencies": {},

--- a/packages/openactive-broker-microservice/package-lock.json
+++ b/packages/openactive-broker-microservice/package-lock.json
@@ -30,20 +30,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@nano-sql/core": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@nano-sql/core/-/core-2.3.7.tgz",
-      "integrity": "sha512-B9nniPPRhPf5Hf2cyvy72SNEg4iKQEW6pig9nwrM4DJlmOMZudifOMPBoJuK6JcTaLATIOGRPkclfosNUALnLQ==",
-      "requires": {
-        "chalk": "^2.4.2",
-        "chokidar": "^3.0.2",
-        "command-line-args": "^5.1.1",
-        "fast-deep-equal": "^2.0.1",
-        "levenshtein-edit-distance": "^2.0.4",
-        "really-small-events": "^1.1.0",
-        "snap-db": "^1.1.1"
-      }
-    },
     "@openactive/test-interface-criteria": {
       "version": "file:../test-interface-criteria",
       "requires": {
@@ -111,18 +97,9 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
-      }
-    },
-    "anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-      "optional": true,
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -133,12 +110,6 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "optional": true
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -230,12 +201,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
-      "optional": true
-    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -263,15 +228,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "optional": true,
-      "requires": {
-        "fill-range": "^7.0.1"
-      }
-    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -292,6 +248,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -303,22 +260,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "chokidar": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
-      "optional": true,
-      "requires": {
-        "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
-        "glob-parent": "~5.1.0",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.2.0"
-      }
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -339,6 +280,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -346,7 +288,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -354,18 +297,6 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
-      }
-    },
-    "command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-      "optional": true,
-      "requires": {
-        "array-back": "^3.0.1",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
       }
     },
     "concat-map": {
@@ -599,7 +530,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "5.16.0",
@@ -914,15 +846,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "optional": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -935,15 +858,6 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
-      }
-    },
-    "find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "optional": true,
-      "requires": {
-        "array-back": "^3.0.1"
       }
     },
     "find-up": {
@@ -1021,12 +935,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-      "optional": true
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -1059,15 +967,6 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-      "optional": true,
-      "requires": {
-        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -1108,7 +1007,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -1257,15 +1157,6 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "optional": true,
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
     "is-callable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
@@ -1278,32 +1169,11 @@
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "optional": true
-    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
-    },
-    "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "optional": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "optional": true
     },
     "is-regex": {
       "version": "1.1.0",
@@ -1412,11 +1282,6 @@
         "verror": "1.10.0"
       }
     },
-    "levenshtein-edit-distance": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-2.0.4.tgz",
-      "integrity": "sha512-yYk99bWzZEqoeaV34ZfO7mjA5z6sIfdnmP9bKMDN6AiQxIqqfjKYAFh51WF1jzlufNtxAkf0YnQL7Cb/vg8gGg=="
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1454,12 +1319,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "optional": true
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -1540,11 +1399,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -1596,12 +1450,6 @@
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
-    },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "optional": true
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -1829,12 +1677,6 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
-    "picomatch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
-      "optional": true
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -1922,20 +1764,6 @@
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
       }
-    },
-    "readdirp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
-      "optional": true,
-      "requires": {
-        "picomatch": "^2.0.4"
-      }
-    },
-    "really-small-events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/really-small-events/-/really-small-events-1.1.0.tgz",
-      "integrity": "sha512-iyh4pULyDYBMecekEYcP3ToJD3ZUdIPfZV9nx1C1lJfMguElkDAZvEMJegy8uE7eIROCuLsqh5r44fVro9nKFg=="
     },
     "regexpp": {
       "version": "2.0.1",
@@ -2122,11 +1950,6 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
-    "snap-db": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/snap-db/-/snap-db-1.1.6.tgz",
-      "integrity": "sha512-KxsO5RnY70J48f6poy0qVm2WS8ZbqG0PUVP2fjd7dvlaCMZ/DxtDv5fhhIVwkP2lOmNQ9QsTFfDuCA7N+TF3qg=="
-    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -2241,6 +2064,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -2304,15 +2128,6 @@
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
-      }
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "optional": true,
-      "requires": {
-        "is-number": "^7.0.0"
       }
     },
     "toidentifier": {
@@ -2384,12 +2199,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
-    },
-    "typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "optional": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/packages/openactive-broker-microservice/package.json
+++ b/packages/openactive-broker-microservice/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "npm run lint",
     "debug": "node --inspect-brk -i app.js",
     "lint": "eslint \"*.js\"",
     "lint-fix": "eslint \"*.js\" --fix"

--- a/packages/openactive-integration-tests/README.md
+++ b/packages/openactive-integration-tests/README.md
@@ -25,15 +25,15 @@ The results of this test suite when run against the reference implementation can
 ## Usage
 1. `npm install`
 2. Ensure the [openactive-broker-microservice](../openactive-broker-microservice/) is running
-3. `npm run test`
+3. `npm start`
 
 ### Running specific tests
 
-`npm run test -- test/features/core/availability-check/implemented/availability-confirmed-test.js`
+`npm start -- test/features/core/availability-check/implemented/availability-confirmed-test.js`
 
 ### Running core tests in a single process
 
-`npm test --runInBand -- test/features/core/`
+`npm start --runInBand -- test/features/core/`
 
 ## Configuration
 
@@ -130,6 +130,6 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for information on the various components
 
 ### Debugging tests
 
-`npm run test --reporters default`
+`npm start --reporters default`
 
 

--- a/packages/openactive-integration-tests/documentation/generator.js
+++ b/packages/openactive-integration-tests/documentation/generator.js
@@ -134,7 +134,7 @@ ${f.coverageStatus !== 'none' ? `
 ### Running tests for only this feature
 
 ${'```'}bash
-npm test --runInBand -- test/features/${f.category}/${f.identifier}/
+npm start --runInBand -- test/features/${f.category}/${f.identifier}/
 ${'```'}
 ` : '*Note the test coverage for this feature is currently non-existant. The test suite does not yet include non-stubbed tests for this feature.*'}
 

--- a/packages/openactive-integration-tests/package.json
+++ b/packages/openactive-integration-tests/package.json
@@ -4,12 +4,11 @@
   "description": "OpenActive booking system integration tests",
   "main": "app.js",
   "scripts": {
-    "start": "echo \"Error: package contains only tests\" && exit 1",
-    "test": "jest",
+    "start": "jest",
+    "test": "npm run lint && tsc",
     "debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand -- test/features/",
     "lint": "eslint \"test/features/**/*.js\"",
     "lint-fix": "eslint \"test/features/**/*.js\" --fix",
-    "static-checks": "npm run lint && tsc",
     "doc-gen": "env NODE_ENV=test node documentation/generator.js",
     "certificate-validator": "env NODE_ENV=test node test/certification/certification-validator-microservice.js"
   },

--- a/packages/openactive-integration-tests/run-specific-test.sh
+++ b/packages/openactive-integration-tests/run-specific-test.sh
@@ -16,7 +16,7 @@ pid=$!
 trap 'err=$?; echo >&2 "Exiting on error $err"; kill $pid; exit $err' ERR
 
 # Run tests
-NODE_CONFIG="{\"useRandomOpportunities\": $1, \"generateConformanceCertificate\": false}" npm test --runInBand -- "${@:2}"
+NODE_CONFIG="{\"useRandomOpportunities\": $1, \"generateConformanceCertificate\": false}" npm start --runInBand -- "${@:2}"
 
 # Kill broker microservice on success
 kill $pid

--- a/packages/openactive-integration-tests/test/features/cancellation/customer-requested-cancellation/README.md
+++ b/packages/openactive-integration-tests/test/features/cancellation/customer-requested-cancellation/README.md
@@ -18,7 +18,7 @@ Opportunities that match the following criteria must exist in the booking system
 ### Running tests for only this feature
 
 ```bash
-npm test --runInBand -- test/features/cancellation/customer-requested-cancellation/
+npm start --runInBand -- test/features/cancellation/customer-requested-cancellation/
 ```
 
 

--- a/packages/openactive-integration-tests/test/features/core/availability-check/README.md
+++ b/packages/openactive-integration-tests/test/features/core/availability-check/README.md
@@ -18,7 +18,7 @@ Opportunities that match the following criteria must exist in the booking system
 ### Running tests for only this feature
 
 ```bash
-npm test --runInBand -- test/features/core/availability-check/
+npm start --runInBand -- test/features/core/availability-check/
 ```
 
 

--- a/packages/openactive-integration-tests/test/features/core/dataset-site/README.md
+++ b/packages/openactive-integration-tests/test/features/core/dataset-site/README.md
@@ -15,7 +15,7 @@ See also: [.NET Tutorial](https://tutorials.openactive.io/open-booking-sdk/quick
 ### Running tests for only this feature
 
 ```bash
-npm test --runInBand -- test/features/core/dataset-site/
+npm start --runInBand -- test/features/core/dataset-site/
 ```
 
 

--- a/packages/openactive-integration-tests/test/features/core/multiple-sellers/README.md
+++ b/packages/openactive-integration-tests/test/features/core/multiple-sellers/README.md
@@ -17,7 +17,7 @@ Opportunities that match the following criteria must exist in the booking system
 ### Running tests for only this feature
 
 ```bash
-npm test --runInBand -- test/features/core/multiple-sellers/
+npm start --runInBand -- test/features/core/multiple-sellers/
 ```
 
 

--- a/packages/openactive-integration-tests/test/features/core/simple-book-free-opportunities/README.md
+++ b/packages/openactive-integration-tests/test/features/core/simple-book-free-opportunities/README.md
@@ -18,7 +18,7 @@ Opportunities that match the following criteria must exist in the booking system
 ### Running tests for only this feature
 
 ```bash
-npm test --runInBand -- test/features/core/simple-book-free-opportunities/
+npm start --runInBand -- test/features/core/simple-book-free-opportunities/
 ```
 
 

--- a/packages/openactive-integration-tests/test/features/core/test-interface/README.md
+++ b/packages/openactive-integration-tests/test/features/core/test-interface/README.md
@@ -16,7 +16,7 @@ Opportunities that match the following criteria must exist in the booking system
 ### Running tests for only this feature
 
 ```bash
-npm test --runInBand -- test/features/core/test-interface/
+npm start --runInBand -- test/features/core/test-interface/
 ```
 
 

--- a/packages/openactive-integration-tests/test/features/payment/simple-book-with-payment/README.md
+++ b/packages/openactive-integration-tests/test/features/payment/simple-book-with-payment/README.md
@@ -18,7 +18,7 @@ Opportunities that match the following criteria must exist in the booking system
 ### Running tests for only this feature
 
 ```bash
-npm test --runInBand -- test/features/payment/simple-book-with-payment/
+npm start --runInBand -- test/features/payment/simple-book-with-payment/
 ```
 
 

--- a/packages/openactive-integration-tests/test/reporter.js
+++ b/packages/openactive-integration-tests/test/reporter.js
@@ -118,7 +118,7 @@ class Reporter {
 
           let validationResult = await validateCertificateHtml(html, CONFORMANCE_CERTIFICATE_ID, certificationWriter.awardedTo.name);
           if (!validationResult || !validationResult.valid) {
-            throw new Error("A valid conformance certificate could not be generated, likely because not all tests were run for this feature configuration. Try simply running `npm test`, without specifying a specific test directory.");
+            throw new Error("A valid conformance certificate could not be generated, likely because not all tests were run for this feature configuration. Try simply running `npm start`, without specifying a specific test directory.");
           }
 
           await mkdirp('./output/certification');

--- a/publish-example-output.sh
+++ b/publish-example-output.sh
@@ -35,7 +35,7 @@ pid=$!
 echo 'Emptying output directory...'
 rm -rf ./packages/openactive-integration-tests/output/
 echo 'Running integration tests with useRandomOpportunities: true...'
-NODE_CONFIG='{"useRandomOpportunities": true, "generateConformanceCertificate": true, "conformanceCertificateId": "https://openactive.io/openactive-test-suite/example-output/random/certification/"}' npm test --prefix packages/openactive-integration-tests --runInBand -- test/features/
+NODE_CONFIG='{"useRandomOpportunities": true, "generateConformanceCertificate": true, "conformanceCertificateId": "https://openactive.io/openactive-test-suite/example-output/random/certification/"}' npm start --prefix packages/openactive-integration-tests --runInBand -- test/features/
 echo 'Copying output files...'
 cp -R ./packages/openactive-integration-tests/output/* ./publish/example-output/random/
 
@@ -43,7 +43,7 @@ cp -R ./packages/openactive-integration-tests/output/* ./publish/example-output/
 echo 'Emptying output directory...'
 rm -rf ./packages/openactive-integration-tests/output/
 echo 'Running integration tests with useRandomOpportunities: false...'
-NODE_CONFIG='{"useRandomOpportunities": false, "generateConformanceCertificate": true, "conformanceCertificateId": "https://openactive.io/openactive-test-suite/example-output/controlled/certification/"}' npm test --prefix packages/openactive-integration-tests --runInBand -- test/features/
+NODE_CONFIG='{"useRandomOpportunities": false, "generateConformanceCertificate": true, "conformanceCertificateId": "https://openactive.io/openactive-test-suite/example-output/controlled/certification/"}' npm start --prefix packages/openactive-integration-tests --runInBand -- test/features/
 echo 'Copying output files...'
 cp -R ./packages/openactive-integration-tests/output/* ./publish/example-output/controlled/
 

--- a/simple-ci.sh
+++ b/simple-ci.sh
@@ -15,7 +15,7 @@ pid=$!
 trap 'err=$?; echo >&2 "Exiting on error $err"; kill $pid; exit $err' ERR
 
 # Run tests
-npm test --prefix packages/openactive-integration-tests
+npm start --prefix packages/openactive-integration-tests
 
 # Kill broker microservice on success
 kill $pid


### PR DESCRIPTION
openactive-test-suite's `npm test` has been repurposed, so that this runs the static checks.

The Booking API tests are now run with `npm start`. This fits with the NPM pattern where `npm test` tests the code itself and `npm start` runs the code. In this case, the code is tests, so the language can be confusing, admittedly