### PR TITLE
chore: Type the FeatureHelper.describeFeature function and its args

### DIFF
--- a/packages/openactive-integration-tests/test/features/core/availability-check/implemented/availability-confirmed-test.js
+++ b/packages/openactive-integration-tests/test/features/core/availability-check/implemented/availability-confirmed-test.js
@@ -1,10 +1,7 @@
-/* eslint-disable no-unused-vars */
 const chakram = require('chakram');
 const chai = require('chai'); // The latest version for new features than chakram includes
 const { FeatureHelper } = require('../../../../helpers/feature-helper');
 const { GetMatch, C1, C2, Common } = require('../../../../shared-behaviours');
-
-/* eslint-enable no-unused-vars */
 
 FeatureHelper.describeFeature(module, {
   testCategory: 'core',

--- a/packages/openactive-integration-tests/test/helpers/feature-helper.js
+++ b/packages/openactive-integration-tests/test/helpers/feature-helper.js
@@ -7,10 +7,56 @@ const { FlowHelper } = require('./flow-helper');
 const BOOKABLE_OPPORTUNITY_TYPES_IN_SCOPE = global.BOOKABLE_OPPORTUNITY_TYPES_IN_SCOPE;
 const IMPLEMENTED_FEATURES = global.IMPLEMENTED_FEATURES;
 
-class FeatureHelper {
-  static describeFeature(documentationModule, configuration, tests) {
-    // Default templates
+/**
+ * @typedef {{
+ *   opportunityType: string | null,
+ *   opportunityCriteria: string,
+ *   primary: boolean,
+ *   control: boolean,
+ *   opportunityReuseKey?: number,
+ *   usedInOrderItems?: number,
+ * }} OpportunityCriteriaTemplate
+ *
+ * @typedef {(opportunityType: string) => [OpportunityCriteriaTemplate]} CreateSingleOportunityCriteriaTemplateFn
+ * @typedef {(opportunityType: string, opportunityReuseKey: number) => OpportunityCriteriaTemplate[]} CreateMultipleOportunityCriteriaTemplateFn
+ *
+ * @typedef {{
+ *   testCategory: string,
+ *   testFeature: string,
+ *   testFeatureImplemented: boolean,
+ *   testIdentifier: string,
+ *   testName: string,
+ *   testDescription: string,
+ *   testOpportunityCriteria?: string,
+ *   controlOpportunityCriteria: string,
+ *   singleOpportunityCriteriaTemplate?: CreateSingleOportunityCriteriaTemplateFn,
+ *   multipleOpportunityCriteriaTemplate?: CreateMultipleOportunityCriteriaTemplateFn,
+ *   runOnce?: boolean,
+ *   skipMultiple?: boolean,
+ *   runOnlyIf?: boolean,
+ * }} DescribeFeatureConfiguration
+ *
+ * @typedef {(
+ *   configuration: DescribeFeatureConfiguration,
+ *   orderItemCriteria: any[],
+ *   implemented: boolean,
+ *   logger: InstanceType<typeof Logger>,
+ *   state: InstanceType<typeof RequestState>,
+ *   flow: InstanceType<typeof FlowHelper>,
+ * ) => void} RunTestsFn
+ */
 
+class FeatureHelper {
+  /**
+   * @param {NodeModule} documentationModule
+   * @param {DescribeFeatureConfiguration} configuration
+   * @param {RunTestsFn} tests
+   */
+  static describeFeature(documentationModule, configuration, tests) {
+    /**
+     * Default templates
+     * @type {CreateSingleOportunityCriteriaTemplateFn}
+     */
     const singleOpportunityCriteriaTemplate = configuration.singleOpportunityCriteriaTemplate 
     || 
     (configuration.testOpportunityCriteria ? ((opportunityType) => [{
@@ -20,7 +66,10 @@ class FeatureHelper {
       control: false,
     }]) : null);
 
-    // Default template: Two of the same opportunity (via opportunityReuseKey), and one different
+    /**
+     * Default template: Two of the same opportunity (via opportunityReuseKey), and one different
+     * @type {CreateMultipleOportunityCriteriaTemplateFn}
+     */
     const multipleOpportunityCriteriaTemplate = configuration.multipleOpportunityCriteriaTemplate
     ||
     (configuration.testOpportunityCriteria ? (opportunityType, i) => [{

--- a/packages/openactive-integration-tests/test/helpers/request-state.js
+++ b/packages/openactive-integration-tests/test/helpers/request-state.js
@@ -41,6 +41,10 @@ class RequestState {
     return this._uuid;
   }
 
+  /**
+   * @param {any[]} orderItemCriteriaList
+   * @param {boolean} [randomModeOverride]
+   */
   async fetchOpportunities(orderItemCriteriaList, randomModeOverride) {
     this.orderItemCriteriaList = orderItemCriteriaList;
 


### PR DESCRIPTION
Relates to issue https://github.com/openactive/openactive-test-suite/issues/91

This means that VSCode will auto-complete things that have been typed e.g. 

![Screenshot 2020-07-17 at 20 41 22](https://user-images.githubusercontent.com/2067438/87824971-26bb7a80-c86e-11ea-9601-3c2b6b9fe62f.png)

and captures errors as you type e.g. 

![Screenshot 2020-07-17 at 20 44 18](https://user-images.githubusercontent.com/2067438/87825055-52d6fb80-c86e-11ea-804a-1aaaff8d785c.png)
