### PR TITLE
fix: Remove prefix anti-pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,15 @@
   "scripts": {
     "start": "node start.js",
     "debug": "node --inspect start.js -- --runInBand",
-    "start-broker": "npm start --prefix packages/openactive-broker-microservice",
-    "start-tests": "npm start --prefix packages/openactive-integration-tests",
-    "install": "cd packages/openactive-broker-microservice && npm install && cd ../openactive-integration-tests && npm install && cd ../..",
-    "test": "npm test --prefix packages/openactive-broker-microservice && npm test --prefix packages/openactive-integration-tests",
-    "certificate-validator": "npm run certificate-validator --prefix packages/openactive-integration-tests"
+    "start-broker": "cd packages/openactive-broker-microservice && npm start",
+    "start-tests": "cd packages/openactive-integration-tests && npm start",
+    "install-broker": "cd packages/openactive-broker-microservice && npm install",
+    "install-tests": "cd packages/openactive-integration-tests && npm install",
+    "install": "npm run install-broker && npm run install-tests",
+    "test-broker": "cd packages/openactive-broker-microservice && npm test",
+    "test-tests": "cd packages/openactive-integration-tests && npm test",
+    "test": "npm run test-broker && npm run test-tests",
+    "certificate-validator": "cd packages/openactive-integration-tests && npm run certificate-validator"
   },
   "dependencies": {
     "node-cleanup": "^2.1.2"


### PR DESCRIPTION
Remove the `--prefix` anti-pattern as it does not work on Windows, and replace with `cd`, as discussed in https://github.com/npm/npm/pull/10958