### PR TITLE
fix: Fix request-helper._request function

### DIFF
--- a/packages/openactive-integration-tests/test/helpers/logger.js
+++ b/packages/openactive-integration-tests/test/helpers/logger.js
@@ -407,6 +407,10 @@ class ReporterLogger extends BaseLogger {
   }
 }
 
+/**
+ * @typedef {InstanceType<typeof BaseLogger>} BaseLoggerType
+ */
+
 module.exports = {
   Logger,
   ReporterLogger,

--- a/packages/openactive-integration-tests/test/helpers/request-helper.js
+++ b/packages/openactive-integration-tests/test/helpers/request-helper.js
@@ -69,7 +69,6 @@ class RequestHelper {
    */
   async get(stage, url, requestOptions) {
     return await this._request(stage, 'GET', url, null, requestOptions);
-    // return await this._request2(stage, )
   }
 
   /**

--- a/packages/openactive-integration-tests/test/helpers/request-helper.js
+++ b/packages/openactive-integration-tests/test/helpers/request-helper.js
@@ -9,6 +9,12 @@ const c2req = require("../templates/c2-req.js");
 const { bReqTemplates } = require("../templates/b-req.js");
 const ureq = require("../templates/u-req.js");
 
+/**
+ * @typedef {import('./logger').BaseLoggerType} BaseLoggerType
+ * @typedef {import('chakram').RequestMethod} RequestMethod
+ * @typedef {import('chakram').RequestOptions} RequestOptions
+ */
+
 const REQUEST_HEADERS = config.get("sellers.primary.requestHeaders");
 
 const MICROSERVICE_BASE = global.MICROSERVICE_BASE;
@@ -16,23 +22,38 @@ const BOOKING_API_BASE = global.BOOKING_API_BASE;
 const TEST_DATASET_IDENTIFIER = global.TEST_DATASET_IDENTIFIER;
 
 class RequestHelper {
+  /**
+   * @param {BaseLoggerType} logger
+   */
   constructor(logger) {
     this.logger = logger;
   }
 
-  async _request(stage, method, url, params, headers) {
-    /** @type {Promise<import('chakram').ChakramResponse>} */
-    const responsePromise = chakram[method.toLowerCase()](url, params, headers);
+  /**
+   * @param {string} stage
+   * @param {RequestMethod} method
+   * @param {string} url
+   * @param {unknown | null} jsonBody Data to send - generally not applicable to
+   *   GET requests. A JSON-serializable object.
+   * @param {RequestOptions} requestOptions
+   */
+  async _request(stage, method, url, jsonBody, requestOptions) {
+    const params = { ...requestOptions };
+    if (jsonBody) {
+      params.body = jsonBody;
+      params.json = true;
+    }
+    const responsePromise = chakram.request(method, url, params);
 
     this.logger.recordRequestResponse(stage, {
       method: method.toUpperCase(),
       url: url,
-      params: params,
-      headers: headers
+      jsonBody,
+      requestOptions,
     }, responsePromise);
 
-    if (params) {
-      this.logger.recordRequest(stage, params);
+    if (jsonBody) {
+      this.logger.recordRequest(stage, jsonBody);
     }
 
     let response = await responsePromise;
@@ -41,23 +62,53 @@ class RequestHelper {
     return response;
   }
 
-  async get(stage, url, headers) {
-    return await this._request(stage, 'GET', url, null, headers);
-  }
-  async put(stage, url, params, headers) {
-    return await this._request(stage, 'PUT', url, params, headers);
-  }
-
-  async post(stage, url, params, headers) {
-    return await this._request(stage, 'POST', url, params, headers);
-  }
-
-  async patch(stage, url, params, headers) {
-    return await this._request(stage, 'PATCH', url, params, headers);
+  /**
+   * @param {string} stage
+   * @param {string} url
+   * @param {RequestOptions} requestOptions
+   */
+  async get(stage, url, requestOptions) {
+    return await this._request(stage, 'GET', url, null, requestOptions);
+    // return await this._request2(stage, )
   }
 
-  async delete(stage, url, params, headers) {
-    return await this._request(stage, 'DELETE', url, params, headers);
+  /**
+   * @param {string} stage
+   * @param {string} url
+   * @param {unknown} jsonBody
+   * @param {RequestOptions} requestOptions
+   */
+  async put(stage, url, jsonBody, requestOptions) {
+    return await this._request(stage, 'PUT', url, jsonBody, requestOptions);
+  }
+
+  /**
+   * @param {string} stage
+   * @param {string} url
+   * @param {unknown} jsonBody
+   * @param {RequestOptions} requestOptions
+   */
+  async post(stage, url, jsonBody, requestOptions) {
+    return await this._request(stage, 'POST', url, jsonBody, requestOptions);
+  }
+
+  /**
+   * @param {string} stage
+   * @param {string} url
+   * @param {unknown} jsonBody
+   * @param {RequestOptions} requestOptions
+   */
+  async patch(stage, url, jsonBody, requestOptions) {
+    return await this._request(stage, 'PATCH', url, jsonBody, requestOptions);
+  }
+
+  /**
+   * @param {string} stage
+   * @param {string} url
+   * @param {RequestOptions} requestOptions
+   */
+  async delete(stage, url, requestOptions) {
+    return await this._request(stage, 'DELETE', url, null, requestOptions);
   }
 
   createHeaders(sellerId) {
@@ -325,7 +376,6 @@ class RequestHelper {
     const respObj = await this.delete(
       'delete-order',
       BOOKING_API_BASE + "orders/" + uuid,
-      null,
       {
         headers: this.createHeaders(params.sellerId),
         timeout: 10000

--- a/packages/openactive-integration-tests/test/types/chakram/index.d.ts
+++ b/packages/openactive-integration-tests/test/types/chakram/index.d.ts
@@ -22,9 +22,13 @@ declare module 'chakram' {
     responseTime: number;
   }
 
-  type RequestOptions = Pick<Options, 'headers' | 'body'>;
+  // `url` is required in request's options, but is not needed in chakram,
+  // because `url` is provided as a separate argument to params
+  export type RequestOptions = Omit<Options, 'url'>;
 
-  export function request(method: string, url: string, params: RequestOptions): Promise<ChakramResponse>;
+  export type RequestMethod = 'GET' | 'PUT' | 'POST' | 'PATCH' | 'DELETE';
+
+  export function request(method: RequestMethod, url: string, params: RequestOptions): Promise<ChakramResponse>;
   export function wait(): Promise<void>;
   // TODO Either detail this or use the more fully featured and already-typed chai.expect()
   export function expect(x: any): any;


### PR DESCRIPTION
This was previously not passing params properly for get requests. It also had confusingly named arguments