### PR TITLE
Ignore JetBrains IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ $RECYCLE.BIN/
 # All except default config
 config/
 !config/default.json
+
+# JetBrains IDE files
+.idea/


### PR DESCRIPTION
Add WebStorm IDE files to `.gitignore`, so we don't accidentally check them in.