### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:12.19.0-alpine3.12 AS openactive.integration_test
+
+WORKDIR /openactive
+
+COPY packages /openactive/packages
+COPY package.json /openactive/package.json
+COPY package-lock.json /openactive/package-lock.json
+COPY start.js /openactive/start.js
+
+WORKDIR /openactive
+RUN npm install
+
+RUN cp -rf /openactive/packages/test-interface-criteria /openactive/packages/openactive-broker-microservice/node_modules/
+RUN cp -rf /openactive/packages/test-interface-criteria /openactive/packages/openactive-integration-tests/node_modules/
+
+VOLUME /openactive/packages/openactive-broker-microservice/config
+VOLUME /openactive/packages/openactive-integration-tests/config
+
+ENTRYPOINT npm start

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ A file named `{NODE_ENV}.json` can also be placed alongside the `default.json`, 
 
 For more information see the [documentation](https://github.com/lorenwest/node-config/wiki/Environment-Variables#node_env).
 
+## Docker
+
+You can run these files on docker by first building the containers:
+```bash
+docker build -t openactive:latest ./
+```
+
+Then simply run the tests:
+
+```
+docker run --rm -v $PWD/packages/openactive-broker-microservice/config:/openactive/packages/openactive-broker-microservice/config openactive
+```
+
 ## Installation
 ```bash
 npm install

--- a/packages/DockerMicroservice
+++ b/packages/DockerMicroservice
@@ -1,0 +1,15 @@
+FROM node AS openactive.microservice
+
+WORKDIR /openactive
+
+RUN mkdir -p openactive-broker-microservice/node_modules/@openactive
+
+COPY openactive-broker-microservice /openactive/openactive-broker-microservice
+COPY test-interface-criteria /openactive/openactive-broker-microservice/node_modules/@openactive/test-interface-criteria
+
+WORKDIR /openactive/openactive-broker-microservice
+
+RUN npm install
+
+EXPOSE 3000
+VOLUME /openactive/openactive-broker-microservice/config

--- a/packages/openactive-broker-microservice/config/default.json
+++ b/packages/openactive-broker-microservice/config/default.json
@@ -3,8 +3,8 @@
   "_local_datasetSiteUrl": "https://localhost:44396/openactive",
   "requestLogging": false,
   "waitForHarvestCompletion": true,
-  "verbose": false,
   "ordersFeedRequestHeaders": {
     "X-OpenActive-Test-Client-Id": "test"
-  }
+  },
+  "verbose": false
 }


### PR DESCRIPTION
This adds experimental Docker support so you can run the tests without needing a specific version of npm installed on your machine. Also allows for a better CI experience as this can be added in the CI pipeline.

In future we should work on reducing the size of the containers (currently ~1GB each) and providing them tagged in the public docker repositories.