### PR TITLE
fix: Capacity limit for IndividualFacilityUse and use of Harvest Start Time

### DIFF
--- a/packages/openactive-broker-microservice/README.md
+++ b/packages/openactive-broker-microservice/README.md
@@ -115,3 +115,13 @@ During development it may be desirable to temporarily disable harvesting of the 
 ```json
   "disableOrdersFeedHarvesting": true,
 ```
+
+### `disableBrokerMicroserviceTimeout`
+
+Opportunities are sorted into test-interface-criteria buckets based on the startDate of the opportunity when it is harvested. The means that the broker microservice must be restarted periodically to ensure its buckets allocation does not get stale. If bucket allocation becomes stale, tests will start to fail randomly.
+
+This property must be set to allow the openactive-broker-microservice to run for more than 1 hour.
+
+```json
+  "disableBrokerMicroserviceTimeout": true,
+```

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -306,7 +306,7 @@ app.get('/health-check', function (req, res) {
   }
 });
 
-// Config endpoint used to set global variables within the integration tests
+// Config endpoint used to get global variables within the integration tests
 app.get('/config', function (req, res) {
   res.json({
     // Allow a consistent startDate to be used when calling test-interface-criteria

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -260,9 +260,9 @@ function setFeedIsUpToDate(feedIdentifier) {
         const { childOrphans, totalChildren, percentageChildOrphans } = getOrphanStats();
 
         if (totalChildren === 0) {
-          logError('\nFATAL ERROR: Zero opportunities could be harvested from the opportunities feed.');
-          logError('Please ensure that the opportunities feed conforms to RPDE using https://validator.openactive.io/rpde.\n');
-          throw new Error('Zero opportunities could be harvested from the opportunities feed');
+          logError('\nFATAL ERROR: Zero opportunities could be harvested from the opportunities feeds.');
+          logError('Please ensure that the opportunities feeds conforms to RPDE using https://validator.openactive.io/rpde.\n');
+          throw new Error('Zero opportunities could be harvested from the opportunities feeds');
         } else if (childOrphans === totalChildren) {
           logError(`\nFATAL ERROR: 100% of the ${totalChildren} harvested opportunities do not have a matching parent item from the parent feed, so all integration tests will fail.`);
           logError('Please ensure that the value of the `subEvent` or `facilityUse` property in each opportunity exactly matches an `@id` from the parent feed.\n');
@@ -838,7 +838,7 @@ async function startPolling() {
   // Only poll orders feed if included in the dataset site
   if (!DO_NOT_HARVEST_ORDERS_FEED && dataset.accessService && dataset.accessService.endpointURL) {
     const feedIdentifier = 'OrdersFeed';
-    const ordersFeedUrl = `${dataset.accessService.endpointURL}orders-rpde`;
+    const ordersFeedUrl = `${dataset.accessService.endpointURL}/orders-rpde`;
     log(`Found orders feed: ${ordersFeedUrl}`);
     addFeed(feedIdentifier);
     harvesters.push(harvestRPDE(ordersFeedUrl, feedIdentifier, ORDERS_FEED_REQUEST_HEADERS, monitorOrdersPage));

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -305,8 +305,18 @@ app.get('/health-check', function (req, res) {
   }
 });
 
+// Config endpoint used to set global variables within the integration tests
+app.get('/config', function (req, res) {
+  res.json({
+    // Allow a consistent startDate to be used when calling test-interface-criteria
+    harvestStartTime: HARVEST_START_TIME.toISOString(),
+    // Base URL used by the integration tests
+    bookingApiBaseUrl: datasetSiteJson.accessService && datasetSiteJson.accessService.endpointURL,
+  });
+});
+
 app.get('/dataset-site', function (req, res) {
-  res.set('X-Harvest-Start-Time', HARVEST_START_TIME.toISOString()).send(datasetSiteJson);
+  res.json(datasetSiteJson);
 });
 
 function mapToObject(map) {

--- a/packages/openactive-integration-tests/test/features/core/dataset-site/implemented/dataset-site-jsonld-valid-test.js
+++ b/packages/openactive-integration-tests/test/features/core/dataset-site/implemented/dataset-site-jsonld-valid-test.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-unused-vars */
 const chakram = require('chakram');
+const chai = require('chai');
 const { RequestState } = require('../../../../helpers/request-state');
 const { FlowHelper } = require('../../../../helpers/flow-helper');
 const { FeatureHelper } = require('../../../../helpers/feature-helper');
 const sharedValidationTests = require('../../../../shared-behaviours/validation');
 const { GetDatasetSite } = require('../../../../shared-behaviours');
 
-const { expect } = chakram;
 /* eslint-enable no-unused-vars */
 
 FeatureHelper.describeFeature(module, {
@@ -28,9 +28,14 @@ function (configuration, orderItemCriteria, featureIsImplemented, logger, state,
       .validationTests();
 
     it('should include accessService.endpointURL of the Open Booking API', () => {
-      expect(state.datasetSite).to.have.schema('accessService.endpointURL', {
+      chakram.expect(state.datasetSite).to.have.schema('accessService.endpointURL', {
         type: 'string',
       });
+    });
+
+    // TODO does validator check that endpointURL does not end in a `/` (as per Open API 3 Base URL https://swagger.io/docs/specification/api-host-and-base-path/)
+    it('should include accessService.endpointURL that does not end in a trailing "/"', () => {
+      chai.expect(state.datasetSite.body.accessService.endpointURL).not.to.match(/\/$/g, 'a trailing /');
     });
   });
 });

--- a/packages/openactive-integration-tests/test/features/restrictions/booking-window/implemented/opportunity-in-range-c1-c2-test.js
+++ b/packages/openactive-integration-tests/test/features/restrictions/booking-window/implemented/opportunity-in-range-c1-c2-test.js
@@ -6,7 +6,7 @@ const { GetMatch, C1, C2 } = require('../../../../shared-behaviours');
  */
 
 FeatureHelper.describeFeature(module, {
-  testCategory: 'restriction',
+  testCategory: 'restrictions',
   testFeature: 'booking-window',
   testFeatureImplemented: true,
   testIdentifier: 'opportunity-in-range-c1-c2',

--- a/packages/openactive-integration-tests/test/global-setup.js
+++ b/packages/openactive-integration-tests/test/global-setup.js
@@ -2,14 +2,14 @@ const assert = require("assert");
 const axios = require("axios");
 const config = require("config");
 
-const MICROSERVICE_BASE = `http://localhost:${process.env.PORT || 3000}/`;
+const MICROSERVICE_BASE = `http://localhost:${process.env.PORT || 3000}`;
 const TEST_DATASET_IDENTIFIER = config.get("testDatasetIdentifier");
 const USE_RANDOM_OPPORTUNITIES = config.get("useRandomOpportunities");
 
 process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
 
 async function ping() {
-  let response = await axios.get(MICROSERVICE_BASE + "health-check/");
+  let response = await axios.get(MICROSERVICE_BASE + "/health-check");
 
   assert.strictEqual(response.data, "openactive-broker");
 
@@ -17,17 +17,17 @@ async function ping() {
 }
 
 async function getEndpointUrl() {
-  let response = await axios.get(MICROSERVICE_BASE + "dataset-site");
+  const response = await axios.get(MICROSERVICE_BASE + "/config");
 
-  if (!(response && response.data && response.data.accessService && response.data.accessService.endpointURL)) {
+  if (!(response && response.data && response.data.bookingApiBaseUrl)) {
     throw new Error("Dataset Site JSON-LD does not contain an accessService.endpointURL");
   }
 
-  return response.data.accessService.endpointURL;
+  return response.data.bookingApiBaseUrl;
 }
 
 async function deleteTestDataset(testInterfaceBaseUrl) {
-  let response = await axios.delete(`${testInterfaceBaseUrl}test-interface/datasets/${TEST_DATASET_IDENTIFIER}`,
+  let response = await axios.delete(`${testInterfaceBaseUrl}/test-interface/datasets/${TEST_DATASET_IDENTIFIER}`,
     {
       timeout: 10000
     }

--- a/packages/openactive-integration-tests/test/global.d.ts
+++ b/packages/openactive-integration-tests/test/global.d.ts
@@ -12,6 +12,7 @@ declare global {
       // These variables are added to Node.js' global object by jest-environment-node
       MICROSERVICE_BASE: string;
       BOOKING_API_BASE?: string;
+      HARVEST_START_TIME: Date;
       TEST_DATASET_IDENTIFIER: string;
       BOOKABLE_OPPORTUNITY_TYPES_IN_SCOPE: { [opportunityType: string]: boolean };
       IMPLEMENTED_FEATURES: { [featureIdentifier: string]: boolean | null };

--- a/packages/openactive-integration-tests/test/helpers/feature-helper.js
+++ b/packages/openactive-integration-tests/test/helpers/feature-helper.js
@@ -88,14 +88,14 @@ class FeatureHelper {
       opportunityCriteria: configuration.testOpportunityCriteria,
       primary: true,
       control: false,
-      opportunityReuseKey: i,
+      opportunityReuseKey: opportunityType === 'IndividualFacilityUseSlot' ? null : i, // IndividualFacilityUseSlot has a capacity limit of 1
     },
     {
       opportunityType,
       opportunityCriteria: configuration.testOpportunityCriteria,
       primary: false,
       control: false,
-      opportunityReuseKey: i,
+      opportunityReuseKey: opportunityType === 'IndividualFacilityUseSlot' ? null : i, // IndividualFacilityUseSlot has a capacity limit of 1
     },
     {
       opportunityType,

--- a/packages/openactive-integration-tests/test/helpers/request-helper.js
+++ b/packages/openactive-integration-tests/test/helpers/request-helper.js
@@ -226,7 +226,7 @@ class RequestHelper {
   async getOrder(uuid) {
     const ordersFeedUpdate = await this.get(
       'get-order',
-      `${MICROSERVICE_BASE}get-order/${uuid}`,
+      `${MICROSERVICE_BASE}/get-order/${uuid}`,
       {
         timeout: 30000,
       },
@@ -242,7 +242,7 @@ class RequestHelper {
   async getMatch(eventId, orderItemPosition) {
     const respObj = await this.get(
       `Opportunity Feed extract for OrderItem ${orderItemPosition}`,
-      `${MICROSERVICE_BASE}opportunity/${encodeURIComponent(eventId)}?useCacheIfAvailable=true`,
+      `${MICROSERVICE_BASE}/opportunity/${encodeURIComponent(eventId)}?useCacheIfAvailable=true`,
       {
         timeout: 60000,
       },
@@ -254,7 +254,7 @@ class RequestHelper {
   async getDatasetSite() {
     const respObj = await this.get(
       'Dataset Site Cached Proxy',
-      `${MICROSERVICE_BASE}dataset-site`,
+      `${MICROSERVICE_BASE}/dataset-site`,
       {
         timeout: 5000,
       },
@@ -274,7 +274,7 @@ class RequestHelper {
 
     const c1Response = await this.put(
       'C1',
-      `${BOOKING_API_BASE}order-quote-templates/${uuid}`,
+      `${BOOKING_API_BASE}/order-quote-templates/${uuid}`,
       payload,
       {
         headers: this.createHeaders(),
@@ -296,7 +296,7 @@ class RequestHelper {
 
     const c2Response = await this.put(
       'C2',
-      `${BOOKING_API_BASE}order-quotes/${uuid}`,
+      `${BOOKING_API_BASE}/order-quotes/${uuid}`,
       payload,
       {
         headers: this.createHeaders(),
@@ -318,7 +318,7 @@ class RequestHelper {
 
     const bResponse = await this.put(
       'B',
-      `${BOOKING_API_BASE}orders/${uuid}`,
+      `${BOOKING_API_BASE}/orders/${uuid}`,
       payload,
       {
         headers: this.createHeaders(),
@@ -340,7 +340,7 @@ class RequestHelper {
 
     const pResponse = await this.put(
       'P',
-      `${BOOKING_API_BASE}order-proposals/${uuid}`,
+      `${BOOKING_API_BASE}/order-proposals/${uuid}`,
       requestBody,
       {
         headers: this.createHeaders(),
@@ -363,7 +363,7 @@ class RequestHelper {
 
     const uResponse = await this.patch(
       'U',
-      `${BOOKING_API_BASE}orders/${uuid}`,
+      `${BOOKING_API_BASE}/orders/${uuid}`,
       payload,
       {
         headers: this.createHeaders(),
@@ -377,7 +377,7 @@ class RequestHelper {
   async createOpportunity(opportunityType, testOpportunityCriteria, orderItemPosition, sellerId, sellerType) {
     const respObj = await this.post(
       `Booking System Test Interface for OrderItem ${orderItemPosition}`,
-      `${BOOKING_API_BASE}test-interface/datasets/${TEST_DATASET_IDENTIFIER}/opportunities`,
+      `${BOOKING_API_BASE}/test-interface/datasets/${TEST_DATASET_IDENTIFIER}/opportunities`,
       this.opportunityCreateRequestTemplate(opportunityType, testOpportunityCriteria, sellerId, sellerType),
       {
         headers: this.createHeaders(),
@@ -391,7 +391,7 @@ class RequestHelper {
   async getRandomOpportunity(opportunityType, testOpportunityCriteria, orderItemPosition, sellerId, sellerType) {
     const respObj = await this.post(
       `Local Microservice Test Interface for OrderItem ${orderItemPosition}`,
-      `${MICROSERVICE_BASE}test-interface/datasets/${TEST_DATASET_IDENTIFIER}/opportunities`,
+      `${MICROSERVICE_BASE}/test-interface/datasets/${TEST_DATASET_IDENTIFIER}/opportunities`,
       this.opportunityCreateRequestTemplate(opportunityType, testOpportunityCriteria, sellerId, sellerType),
       {
         timeout: 10000,
@@ -411,7 +411,7 @@ class RequestHelper {
   async callTestInterfaceAction({ action: { type, objectType, objectId } }) {
     const response = await this.post(
       `Call TestInterface Action of type: ${type}`,
-      `${BOOKING_API_BASE}test-interface/actions`,
+      `${BOOKING_API_BASE}/test-interface/actions`,
       {
         '@context': [
           'https://openactive.io/',
@@ -438,7 +438,7 @@ class RequestHelper {
   async deleteOrder(uuid, params) {
     const respObj = await this.delete(
       'delete-order',
-      `${BOOKING_API_BASE}orders/${uuid}`,
+      `${BOOKING_API_BASE}/orders/${uuid}`,
       {
         headers: this.createHeaders(),
         timeout: 10000,

--- a/packages/openactive-integration-tests/test/helpers/request-state.js
+++ b/packages/openactive-integration-tests/test/helpers/request-state.js
@@ -88,7 +88,7 @@ class RequestState {
      */
     this.testInterfaceResponses = await Promise.all((this.orderItemCriteriaList || []).map(async (orderItemCriteriaItem, i) => {
       // If an opportunity is available for reuse, return it
-      if (orderItemCriteriaItem.hasOwnProperty('opportunityReuseKey') && reusableOpportunityPromises.has(orderItemCriteriaItem.opportunityReuseKey)) {
+      if (orderItemCriteriaItem.hasOwnProperty('opportunityReuseKey') && orderItemCriteriaItem.opportunityReuseKey !== null && reusableOpportunityPromises.has(orderItemCriteriaItem.opportunityReuseKey)) {
         return await reusableOpportunityPromises.get(orderItemCriteriaItem.opportunityReuseKey);
       }
 
@@ -99,7 +99,7 @@ class RequestState {
         : this.requestHelper.createOpportunity(orderItemCriteriaItem.opportunityType, orderItemCriteriaItem.opportunityCriteria, i, seller['@id'], seller['@type']);
 
       // If this opportunity can be reused, store it
-      if (orderItemCriteriaItem.hasOwnProperty('opportunityReuseKey')) {
+      if (orderItemCriteriaItem.hasOwnProperty('opportunityReuseKey') && orderItemCriteriaItem.opportunityReuseKey !== null) {
         reusableOpportunityPromises.set(orderItemCriteriaItem.opportunityReuseKey, opportunityPromise);
       }
 

--- a/packages/openactive-integration-tests/test/helpers/request-state.js
+++ b/packages/openactive-integration-tests/test/helpers/request-state.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const { getRelevantOffers } = require('@openactive/test-interface-criteria');
 const config = require('config');
 const RequestHelper = require('./request-helper');
@@ -88,7 +89,7 @@ class RequestState {
      */
     this.testInterfaceResponses = await Promise.all((this.orderItemCriteriaList || []).map(async (orderItemCriteriaItem, i) => {
       // If an opportunity is available for reuse, return it
-      if (!_.isNil(orderItemCriteriaItem.opportunityReuseKey') && reusableOpportunityPromises.has(orderItemCriteriaItem.opportunityReuseKey)) {
+      if (!_.isNil(orderItemCriteriaItem.opportunityReuseKey) && reusableOpportunityPromises.has(orderItemCriteriaItem.opportunityReuseKey)) {
         return await reusableOpportunityPromises.get(orderItemCriteriaItem.opportunityReuseKey);
       }
 

--- a/packages/openactive-integration-tests/test/helpers/request-state.js
+++ b/packages/openactive-integration-tests/test/helpers/request-state.js
@@ -88,7 +88,7 @@ class RequestState {
      */
     this.testInterfaceResponses = await Promise.all((this.orderItemCriteriaList || []).map(async (orderItemCriteriaItem, i) => {
       // If an opportunity is available for reuse, return it
-      if (orderItemCriteriaItem.hasOwnProperty('opportunityReuseKey') && orderItemCriteriaItem.opportunityReuseKey !== null && reusableOpportunityPromises.has(orderItemCriteriaItem.opportunityReuseKey)) {
+      if (!_.isNil(orderItemCriteriaItem.opportunityReuseKey') && reusableOpportunityPromises.has(orderItemCriteriaItem.opportunityReuseKey)) {
         return await reusableOpportunityPromises.get(orderItemCriteriaItem.opportunityReuseKey);
       }
 
@@ -99,7 +99,7 @@ class RequestState {
         : this.requestHelper.createOpportunity(orderItemCriteriaItem.opportunityType, orderItemCriteriaItem.opportunityCriteria, i, seller['@id'], seller['@type']);
 
       // If this opportunity can be reused, store it
-      if (orderItemCriteriaItem.hasOwnProperty('opportunityReuseKey') && orderItemCriteriaItem.opportunityReuseKey !== null) {
+      if (!_.isNil(orderItemCriteriaItem.opportunityReuseKey)) {
         reusableOpportunityPromises.set(orderItemCriteriaItem.opportunityReuseKey, opportunityPromise);
       }
 

--- a/packages/openactive-integration-tests/test/helpers/request-state.js
+++ b/packages/openactive-integration-tests/test/helpers/request-state.js
@@ -9,6 +9,7 @@ const { generateUuid } = require('./generate-uuid');
 
 const USE_RANDOM_OPPORTUNITIES = config.get('useRandomOpportunities');
 const SELLER_CONFIG = config.get('sellers');
+const { HARVEST_START_TIME } = global;
 
 function isResponse20x(response) {
   if (!response || !response.response) return false;
@@ -106,9 +107,9 @@ class RequestState {
     }));
   }
 
-  getRandomRelevantOffer(opportunity, opportunityCriteria) {
-    const relevantOffers = getRelevantOffers(opportunityCriteria, opportunity);
-    if (relevantOffers.length == 0) return null;
+  static getRandomRelevantOffer(opportunity, opportunityCriteria) {
+    const relevantOffers = getRelevantOffers(opportunityCriteria, opportunity, { harvestStartTime: HARVEST_START_TIME });
+    if (relevantOffers.length === 0) return null;
 
     return relevantOffers[Math.floor(Math.random() * relevantOffers.length)];
   }
@@ -168,7 +169,7 @@ class RequestState {
 
     this.orderItems = (this.opportunityFeedExtractResponses || []).map((x, i) => {
       if (x && isResponse20x(x)) {
-        const acceptedOffer = this.getRandomRelevantOffer(x.body.data, this.orderItemCriteriaList[i].opportunityCriteria);
+        const acceptedOffer = RequestState.getRandomRelevantOffer(x.body.data, this.orderItemCriteriaList[i].opportunityCriteria);
         if (acceptedOffer === null) {
           throw new Error(`Opportunity for OrderItem ${i} did not have a relevant offer for the specified testOpportunityCriteria: ${this.orderItemCriteriaList[i].opportunityCriteria}`);
         }

--- a/packages/openactive-integration-tests/test/reporter.js
+++ b/packages/openactive-integration-tests/test/reporter.js
@@ -12,7 +12,7 @@ const {ReportGenerator, SummaryReportGenerator} = require('./report-generator');
 const {CertificationWriter} = require('./certification/certification-writer');
 const {validateCertificateHtml} = require('./certification/certification-validator');
 
-const MICROSERVICE_BASE = `http://localhost:${process.env.PORT || 3000}/`;
+const MICROSERVICE_BASE = `http://localhost:${process.env.PORT || 3000}`;
 const GENERATE_CONFORMANCE_CERTIFICATE = config.has('generateConformanceCertificate') && config.get('generateConformanceCertificate');
 const CONFORMANCE_CERTIFICATE_ID = GENERATE_CONFORMANCE_CERTIFICATE ? config.get('conformanceCertificateId') : null;
 const OUTPUT_PATH = config.get('outputPath');
@@ -72,7 +72,7 @@ class Reporter {
 
   // based on https://github.com/pierreroth64/jest-spec-reporter/blob/master/lib/jest-spec-reporter.js
   async onRunComplete(test, results) {
-    let datasetJson = await axios.get(MICROSERVICE_BASE + "dataset-site");
+    let datasetJson = await axios.get(MICROSERVICE_BASE + "/dataset-site");
     datasetJson = datasetJson && datasetJson.data;
 
     let loggers = await SummaryReportGenerator.getLoggersFromFiles();

--- a/packages/openactive-integration-tests/test/shared-behaviours/validation.js
+++ b/packages/openactive-integration-tests/test/shared-behaviours/validation.js
@@ -2,6 +2,8 @@ const assert = require("assert");
 const { validate } = require("@openactive/data-model-validator");
 const { criteriaMap, testMatch } = require("@openactive/test-interface-criteria");
 
+const { HARVEST_START_TIME } = global;
+
 /**
  * @typedef {import('chakram').ChakramResponse} ChakramResponse
  * @typedef {import('../helpers/logger').BaseLoggerType} BaseLoggerType
@@ -48,7 +50,7 @@ function shouldBeValidResponse(getter, name, logger, options, opportunityCriteri
         throw new Error(`Criteria '${criteriaName}' not supported by the @openactive/test-interface-criteria library`);
       }
 
-      let { matchesCriteria, unmetCriteriaDetails } = testMatch(criteriaMap.get(criteriaName), body);
+      let { matchesCriteria, unmetCriteriaDetails } = testMatch(criteriaMap.get(criteriaName), body, { harvestStartTime: HARVEST_START_TIME });
   
       if (!matchesCriteria) {
         throw new Error(`Does not match criteria https://openactive.io/test-interface#${criteriaName}: ${unmetCriteriaDetails.join(', ')}`);

--- a/packages/openactive-integration-tests/test/templates/u-req.js
+++ b/packages/openactive-integration-tests/test/templates/u-req.js
@@ -35,7 +35,7 @@ function createNonExistantOrderUReq(data) {
     orderedItem: [
       {
         '@type': 'OrderItem',
-        '@id': `${BOOKING_API_BASE}orders/${data._uuid}#/orderedItems/1`, // non existant OrderItem on non existant Order
+        '@id': `${BOOKING_API_BASE}/orders/${data._uuid}#/orderedItems/1`, // non existant OrderItem on non existant Order
         orderItemStatus: 'https://openactive.io/CustomerCancelled',
       },
     ],

--- a/packages/openactive-integration-tests/test/testEnvironment.js
+++ b/packages/openactive-integration-tests/test/testEnvironment.js
@@ -2,7 +2,7 @@ const NodeEnvironment = require('jest-environment-node');
 const axios = require('axios');
 const config = require('config');
 
-const MICROSERVICE_BASE = `http://localhost:${process.env.PORT || 3000}/`;
+const MICROSERVICE_BASE = `http://localhost:${process.env.PORT || 3000}`;
 const TEST_DATASET_IDENTIFIER = config.get('testDatasetIdentifier');
 
 const BOOKABLE_OPPORTUNITY_TYPES_IN_SCOPE = config.get('bookableOpportunityTypesInScope');
@@ -17,7 +17,7 @@ class TestEnvironment extends NodeEnvironment {
     await super.setup();
 
     // Get endpoint URL from Dataset Site
-    const configUrl = `${MICROSERVICE_BASE}config`;
+    const configUrl = `${MICROSERVICE_BASE}/config`;
     const response = await axios.get(configUrl);
     if (response && response.data) {
       this.global.BOOKING_API_BASE = response.data.bookingApiBaseUrl;

--- a/packages/openactive-integration-tests/test/testEnvironment.js
+++ b/packages/openactive-integration-tests/test/testEnvironment.js
@@ -20,6 +20,7 @@ class TestEnvironment extends NodeEnvironment {
     let response = await axios.get(MICROSERVICE_BASE + "dataset-site");
     if (response && response.data && response.data.accessService && response.data.accessService.endpointURL) {
       this.global.BOOKING_API_BASE = response.data.accessService.endpointURL;
+      this.global.HARVEST_START_TIME = new Date(response.headers['X-Harvest-Start-Time']);
     }
     this.global.MICROSERVICE_BASE = MICROSERVICE_BASE;
     this.global.TEST_DATASET_IDENTIFIER = TEST_DATASET_IDENTIFIER;

--- a/packages/openactive-integration-tests/test/testEnvironment.js
+++ b/packages/openactive-integration-tests/test/testEnvironment.js
@@ -1,9 +1,9 @@
 const NodeEnvironment = require('jest-environment-node');
-const axios = require("axios");
-const config = require("config");
+const axios = require('axios');
+const config = require('config');
 
 const MICROSERVICE_BASE = `http://localhost:${process.env.PORT || 3000}/`;
-const TEST_DATASET_IDENTIFIER = config.get("testDatasetIdentifier");
+const TEST_DATASET_IDENTIFIER = config.get('testDatasetIdentifier');
 
 const BOOKABLE_OPPORTUNITY_TYPES_IN_SCOPE = config.get('bookableOpportunityTypesInScope');
 const IMPLEMENTED_FEATURES = config.get('implementedFeatures');
@@ -17,10 +17,13 @@ class TestEnvironment extends NodeEnvironment {
     await super.setup();
 
     // Get endpoint URL from Dataset Site
-    let response = await axios.get(MICROSERVICE_BASE + "dataset-site");
-    if (response && response.data && response.data.accessService && response.data.accessService.endpointURL) {
-      this.global.BOOKING_API_BASE = response.data.accessService.endpointURL;
-      this.global.HARVEST_START_TIME = new Date(response.headers['X-Harvest-Start-Time']);
+    const configUrl = `${MICROSERVICE_BASE}config`;
+    const response = await axios.get(configUrl);
+    if (response && response.data) {
+      this.global.BOOKING_API_BASE = response.data.bookingApiBaseUrl;
+      this.global.HARVEST_START_TIME = new Date(response.data.harvestStartTime);
+    } else {
+      throw new Error(`Error accessing broker microservice at ${configUrl}`);
     }
     this.global.MICROSERVICE_BASE = MICROSERVICE_BASE;
     this.global.TEST_DATASET_IDENTIFIER = TEST_DATASET_IDENTIFIER;

--- a/packages/openactive-integration-tests/test/testEnvironment.js
+++ b/packages/openactive-integration-tests/test/testEnvironment.js
@@ -16,7 +16,7 @@ class TestEnvironment extends NodeEnvironment {
   async setup() {
     await super.setup();
 
-    // Get endpoint URL from Dataset Site
+    // Get endpoint URL from Broker Microservice
     const configUrl = `${MICROSERVICE_BASE}/config`;
     const response = await axios.get(configUrl);
     if (response && response.data) {

--- a/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookableCancellable.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookableCancellable.d.ts
@@ -1,4 +1,4 @@
-export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity) => boolean;
+export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
 /**
  * Implements https://openactive.io/test-interface#TestOpportunityBookableCancellable
  */

--- a/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookableFiveSpaces.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookableFiveSpaces.d.ts
@@ -1,4 +1,4 @@
-export type OpportunityConstraint = (opportunity: import("../types/Opportunity").Opportunity) => boolean;
+export type OpportunityConstraint = (opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
 /**
  * Implements https://openactive.io/test-interface#TestOpportunityBookableFiveSpaces
  */

--- a/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookableFree.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookableFree.d.ts
@@ -1,4 +1,4 @@
-export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity) => boolean;
+export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
 /**
  * Implements https://openactive.io/test-interface#TestOpportunityBookableFree
  */

--- a/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookableNoSpaces.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookableNoSpaces.d.ts
@@ -1,4 +1,4 @@
-export type OpportunityConstraint = (opportunity: import("../types/Opportunity").Opportunity) => boolean;
+export type OpportunityConstraint = (opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
 /**
  * Implements https://openactive.io/test-interface#TestOpportunityBookableNoSpaces
  */

--- a/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookableOutsideValidFromBeforeStartDate.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookableOutsideValidFromBeforeStartDate.d.ts
@@ -1,4 +1,4 @@
-export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity) => boolean;
+export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
 /**
  * Implements https://openactive.io/test-interface#TestOpportunityBookableOutsideValidFromBeforeStartDate
  */

--- a/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookablePaid.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/TestOpportunityBookablePaid.d.ts
@@ -1,4 +1,4 @@
-export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity) => boolean;
+export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
 /**
  * Implements https://openactive.io/test-interface#TestOpportunityBookablePaid
  */

--- a/packages/test-interface-criteria/built-types/criteria/TestOpportunityNotBookableViaAvailableChannel.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/TestOpportunityNotBookableViaAvailableChannel.d.ts
@@ -1,4 +1,4 @@
-export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity) => boolean;
+export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
 /**
  * Implements https://openactive.io/test-interface#TestOpportunityNotBookableViaAvailableChannel
  */

--- a/packages/test-interface-criteria/built-types/criteria/criteriaUtils.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/criteriaUtils.d.ts
@@ -6,7 +6,7 @@ export type Offer = {
     '@type': string;
     '@id': string;
 };
-export type OpportunityConstraint = (opportunity: import("../types/Opportunity").Opportunity) => boolean;
+export type OpportunityConstraint = (opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
 export type Criteria = {
     name: string;
     opportunityConstraints: [string, import("../types/Criteria").OpportunityConstraint][];
@@ -55,3 +55,8 @@ export function getRemainingCapacity(opportunity: Opportunity): number | null | 
  * @param {Opportunity} opportunity
  */
 export function mustBeWithinBookingWindow(offer: Offer, opportunity: Opportunity): boolean;
+/**
+ * @param {Opportunity} opportunity
+ * @returns {boolean}
+ */
+export function hasCapacityLimitOfOne(opportunity: Opportunity): boolean;

--- a/packages/test-interface-criteria/built-types/criteria/criteriaUtils.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/criteriaUtils.d.ts
@@ -7,6 +7,7 @@ export type Offer = {
     '@id': string;
 };
 export type OpportunityConstraint = (opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
+export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
 export type Criteria = {
     name: string;
     opportunityConstraints: [string, import("../types/Criteria").OpportunityConstraint][];
@@ -16,6 +17,7 @@ export type Criteria = {
  * @typedef {import('../types/Opportunity').Opportunity} Opportunity
  * @typedef {import('../types/Offer').Offer} Offer
  * @typedef {import('../types/Criteria').OpportunityConstraint} OpportunityConstraint
+ * @typedef {import('../types/Criteria').OfferConstraint} OfferConstraint
  * @typedef {import('../types/Criteria').Criteria} Criteria
  */
 /**
@@ -53,7 +55,7 @@ export function getRemainingCapacity(opportunity: Opportunity): number | null | 
 /**
  * @type {OfferConstraint}
  */
-export function mustBeWithinBookingWindow(offer: any, opportunity: any, options: any): boolean;
+export function mustBeWithinBookingWindow(offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity, options: import("../types/Options").Options): boolean;
 /**
  * @param {Opportunity} opportunity
  * @returns {boolean}

--- a/packages/test-interface-criteria/built-types/criteria/criteriaUtils.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/criteriaUtils.d.ts
@@ -51,10 +51,9 @@ export function getType(opportunity: Opportunity): string;
  */
 export function getRemainingCapacity(opportunity: Opportunity): number | null | undefined;
 /**
- * @param {Offer} offer
- * @param {Opportunity} opportunity
+ * @type {OfferConstraint}
  */
-export function mustBeWithinBookingWindow(offer: Offer, opportunity: Opportunity): boolean;
+export function mustBeWithinBookingWindow(offer: any, opportunity: any, options: any): boolean;
 /**
  * @param {Opportunity} opportunity
  * @returns {boolean}

--- a/packages/test-interface-criteria/built-types/criteria/internal/InternalCriteriaFutureScheduledOpportunity.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/internal/InternalCriteriaFutureScheduledOpportunity.d.ts
@@ -3,7 +3,7 @@ export type Criteria = {
     opportunityConstraints: [string, import("../../types/Criteria").OpportunityConstraint][];
     offerConstraints: [string, import("../../types/Criteria").OfferConstraint][];
 };
-export type OpportunityConstraint = (opportunity: import("../../types/Opportunity").Opportunity) => boolean;
+export type OpportunityConstraint = (opportunity: import("../../types/Opportunity").Opportunity, options?: import("../../types/Options").Options) => boolean;
 /**
  * Useful base filters for future opportunities
  */

--- a/packages/test-interface-criteria/built-types/criteria/internal/InternalTestOpportunityBookable.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/internal/InternalTestOpportunityBookable.d.ts
@@ -1,5 +1,5 @@
-export type OpportunityConstraint = (opportunity: import("../../types/Opportunity").Opportunity) => boolean;
-export type OfferConstraint = (offer: import("../../types/Offer").Offer, opportunity: import("../../types/Opportunity").Opportunity) => boolean;
+export type OpportunityConstraint = (opportunity: import("../../types/Opportunity").Opportunity, options?: import("../../types/Options").Options) => boolean;
+export type OfferConstraint = (offer: import("../../types/Offer").Offer, opportunity: import("../../types/Opportunity").Opportunity, options?: import("../../types/Options").Options) => boolean;
 /**
  * Internal criteria which almost implements https://openactive.io/test-interface#TestOpportunityBookable
  * but handily leaves out anything related to openBookingFlowRequirement, so

--- a/packages/test-interface-criteria/built-types/criteria/sharedConstraints.d.ts
+++ b/packages/test-interface-criteria/built-types/criteria/sharedConstraints.d.ts
@@ -1,4 +1,4 @@
-export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity) => boolean;
+export type OfferConstraint = (offer: import("../types/Offer").Offer, opportunity: import("../types/Opportunity").Opportunity, options?: import("../types/Options").Options) => boolean;
 /**
  * @typedef {import('../types/Criteria').OfferConstraint} OfferConstraint
  */

--- a/packages/test-interface-criteria/built-types/index.d.ts
+++ b/packages/test-interface-criteria/built-types/index.d.ts
@@ -25,11 +25,15 @@ export type Offer = {
     '@type': string;
     '@id': string;
 };
+export type Options = {
+    harvestStartTime: Date;
+};
 declare const allCriteria: import("./types/Criteria").Criteria[];
 /**
  * @typedef {import('./types/Criteria').Criteria} Criteria
  * @typedef {import('./types/Opportunity').Opportunity} Opportunity
  * @typedef {import('./types/Offer').Offer} Offer
+ * @typedef {import('./types/Options').Options} Options
  */
 export const criteriaMap: Map<string, import("./types/Criteria").Criteria>;
 /**
@@ -42,14 +46,16 @@ export const criteriaMap: Map<string, import("./types/Criteria").Criteria>;
  *
  * @param {Criteria} criteria
  * @param {Opportunity} opportunity
+ * @param {Options} options
  */
-export function testMatch(criteria: Criteria, opportunity: Opportunity): {
+export function testMatch(criteria: Criteria, opportunity: Opportunity, options: Options): {
     matchesCriteria: boolean;
     unmetCriteriaDetails: string[];
 };
 /**
  * @param {string} criteriaName
  * @param {Opportunity} opportunity
+ * @param {Options} options
  */
-export function getRelevantOffers(criteriaName: string, opportunity: Opportunity): import("./types/Offer").Offer[];
+export function getRelevantOffers(criteriaName: string, opportunity: Opportunity, options: Options): import("./types/Offer").Offer[];
 export { allCriteria as criteria };

--- a/packages/test-interface-criteria/built-types/types/Criteria.d.ts
+++ b/packages/test-interface-criteria/built-types/types/Criteria.d.ts
@@ -1,9 +1,10 @@
 import { Opportunity } from './Opportunity';
 import { Offer } from './Offer';
+import { Options } from './Options';
 
-export type OpportunityConstraint = (opportunity: Opportunity) => boolean;
+export type OpportunityConstraint = (opportunity: Opportunity, options?: Options) => boolean;
 
-export type OfferConstraint = (offer: Offer, opportunity: Opportunity) => boolean;
+export type OfferConstraint = (offer: Offer, opportunity: Opportunity, options?: Options) => boolean;
 
 export type Criteria = {
   name: string,

--- a/packages/test-interface-criteria/built-types/types/Options.d.ts
+++ b/packages/test-interface-criteria/built-types/types/Options.d.ts
@@ -1,0 +1,3 @@
+export type Options = {
+  harvestStartTime: Date,
+};

--- a/packages/test-interface-criteria/src/criteria/TestOpportunityBookableFiveSpaces.js
+++ b/packages/test-interface-criteria/src/criteria/TestOpportunityBookableFiveSpaces.js
@@ -8,8 +8,8 @@ const { createCriteria, getRemainingCapacity } = require('./criteriaUtils');
 /**
  * @type {OpportunityConstraint}
  */
-function remainingCapacityMustBeFive(opportunityConstraint) {
-  return getRemainingCapacity(opportunityConstraint) === 5;
+function remainingCapacityMustBeFive(opportunity) {
+  return getRemainingCapacity(opportunity) === 5;
 }
 
 /**

--- a/packages/test-interface-criteria/src/criteria/TestOpportunityBookableOutsideValidFromBeforeStartDate.js
+++ b/packages/test-interface-criteria/src/criteria/TestOpportunityBookableOutsideValidFromBeforeStartDate.js
@@ -10,10 +10,10 @@ const { createCriteria } = require('./criteriaUtils');
 /**
  * @type {OfferConstraint}
  */
-function outsideValidFromBeforeStartDate(offer, opportunity) {
+function outsideValidFromBeforeStartDate(offer, opportunity, options) {
   return (Array.isArray(offer.availableChannel) && offer.availableChannel.includes('https://openactive.io/OpenBookingPrepayment'))
     && offer.advanceBooking !== 'https://openactive.io/Unavailable'
-    && (offer.validFromBeforeStartDate && moment(opportunity.startDate).subtract(moment.duration(offer.validFromBeforeStartDate)).isAfter());
+    && (offer.validFromBeforeStartDate && moment(opportunity.startDate).subtract(moment.duration(offer.validFromBeforeStartDate)).isAfter(options.harvestStartTime));
 }
 
 /**

--- a/packages/test-interface-criteria/src/criteria/criteriaUtils.js
+++ b/packages/test-interface-criteria/src/criteria/criteriaUtils.js
@@ -4,6 +4,7 @@ const moment = require('moment');
  * @typedef {import('../types/Opportunity').Opportunity} Opportunity
  * @typedef {import('../types/Offer').Offer} Offer
  * @typedef {import('../types/Criteria').OpportunityConstraint} OpportunityConstraint
+ * @typedef {import('../types/Criteria').OfferConstraint} OfferConstraint
  * @typedef {import('../types/Criteria').Criteria} Criteria
  */
 
@@ -70,19 +71,17 @@ function getRemainingCapacity(opportunity) {
 }
 
 /**
- * @param {Offer} offer
- * @param {Opportunity} opportunity
+ * @type {OfferConstraint}
  */
-function mustBeWithinBookingWindow(offer, opportunity) {
+function mustBeWithinBookingWindow(offer, opportunity, options) {
   if (!offer || !offer.validFromBeforeStartDate) {
     return false;
   }
 
-  const now = moment();
   const start = moment(opportunity.startDate);
   const duration = moment.duration(offer.validFromBeforeStartDate);
 
-  const valid = start.subtract(duration) <= now;
+  const valid = start.subtract(duration).isBefore(options.harvestStartTime);
   return valid;
 }
 

--- a/packages/test-interface-criteria/src/criteria/criteriaUtils.js
+++ b/packages/test-interface-criteria/src/criteria/criteriaUtils.js
@@ -49,6 +49,16 @@ function getType(opportunity) {
   return opportunity['@type'] || opportunity.type;
 }
 
+
+/**
+ * @param {Opportunity} opportunity
+ * @returns {boolean}
+ */
+function hasCapacityLimitOfOne(opportunity) {
+  // return true for a Slot of an IndividualFacilityUse
+  return opportunity && opportunity.facilityUse && getType(opportunity.facilityUse) === 'IndividualFacilityUse';
+}
+
 /**
  * @param {Opportunity} opportunity
  * @returns {number | null | undefined} Not all opportunities have
@@ -82,4 +92,5 @@ module.exports = {
   getType,
   getRemainingCapacity,
   mustBeWithinBookingWindow,
+  hasCapacityLimitOfOne,
 };

--- a/packages/test-interface-criteria/src/criteria/criteriaUtils.js
+++ b/packages/test-interface-criteria/src/criteria/criteriaUtils.js
@@ -56,7 +56,7 @@ function getType(opportunity) {
  * @returns {boolean}
  */
 function hasCapacityLimitOfOne(opportunity) {
-  // return true for a Slot of an IndividualFacilityUse
+  // return true for a Slot of an IndividualFacilityUse, which is limited to a maximumUses of 1 by the specification.
   return opportunity && opportunity.facilityUse && getType(opportunity.facilityUse) === 'IndividualFacilityUse';
 }
 

--- a/packages/test-interface-criteria/src/criteria/internal/InternalTestOpportunityBookable.js
+++ b/packages/test-interface-criteria/src/criteria/internal/InternalTestOpportunityBookable.js
@@ -12,6 +12,8 @@ const { getRemainingCapacity, createCriteria, hasCapacityLimitOfOne } = require(
  * @type {OpportunityConstraint}
  */
 function remainingCapacityMustBeAtLeastTwo(opportunity) {
+  // A capacity of at least 2 is needed for cases other than IndividualFacilityUse because the multiple OrderItem tests use 2 of the same item (via the opportunityReuseKey).
+  // The opportunityReuseKey is not used for IndividualFacilityUse, which is limited to a maximumUses of 1 by the specification.
   return getRemainingCapacity(opportunity) > (hasCapacityLimitOfOne(opportunity) ? 0 : 1);
 }
 

--- a/packages/test-interface-criteria/src/criteria/internal/InternalTestOpportunityBookable.js
+++ b/packages/test-interface-criteria/src/criteria/internal/InternalTestOpportunityBookable.js
@@ -1,7 +1,7 @@
 const moment = require('moment');
 
 const { InternalCriteriaFutureScheduledOpportunity } = require('../internal/InternalCriteriaFutureScheduledOpportunity');
-const { getRemainingCapacity, createCriteria, mustBeWithinBookingWindow } = require('../criteriaUtils');
+const { getRemainingCapacity, createCriteria, hasCapacityLimitOfOne } = require('../criteriaUtils');
 
 /**
  * @typedef {import('../../types/Criteria').OpportunityConstraint} OpportunityConstraint
@@ -12,23 +12,16 @@ const { getRemainingCapacity, createCriteria, mustBeWithinBookingWindow } = requ
  * @type {OpportunityConstraint}
  */
 function remainingCapacityMustBeAtLeastTwo(opportunity) {
-  return getRemainingCapacity(opportunity) > 1;
+  return getRemainingCapacity(opportunity) > (hasCapacityLimitOfOne(opportunity) ? 0 : 1);
 }
 
 /**
  * @type {OfferConstraint}
  */
-function mustHaveBookableOffer(offer, opportunity) {
+function mustHaveBookableOffer(offer, opportunity, options) {
   return (Array.isArray(offer.availableChannel) && offer.availableChannel.includes('https://openactive.io/OpenBookingPrepayment'))
     && offer.advanceBooking !== 'https://openactive.io/Unavailable'
-    && (!offer.validFromBeforeStartDate || moment(opportunity.startDate).subtract(moment.duration(offer.validFromBeforeStartDate)).isBefore());
-}
-
-/**
-* @type {OfferConstraint}
-*/
-function mustIfThereIsABookableWindowBeWithinIt(offer, opportunity) {
-  return !(offer && offer.validFromBeforeStartDate) || mustBeWithinBookingWindow(offer, opportunity);
+    && (!offer.validFromBeforeStartDate || moment(opportunity.startDate).subtract(moment.duration(offer.validFromBeforeStartDate)).isBefore(options.harvestStartTime));
 }
 
 /**
@@ -41,15 +34,11 @@ const InternalTestOpportunityBookable = createCriteria({
   name: '_InternalTestOpportunityBookable',
   opportunityConstraints: [
     [
-      'Remaining capacity must be at least two',
+      'Remaining capacity must be at least two (or one for IndividualFacilityUse)',
       remainingCapacityMustBeAtLeastTwo,
     ],
   ],
   offerConstraints: [
-    [
-      'Must, if there is a bookahead window, be within it',
-      mustIfThereIsABookableWindowBeWithinIt,
-    ],
     [
       'Must have "bookable" offer',
       mustHaveBookableOffer,

--- a/packages/test-interface-criteria/src/index.js
+++ b/packages/test-interface-criteria/src/index.js
@@ -8,6 +8,7 @@ const { allCriteria } = require('./criteria');
  * @typedef {import('./types/Criteria').Criteria} Criteria
  * @typedef {import('./types/Opportunity').Opportunity} Opportunity
  * @typedef {import('./types/Offer').Offer} Offer
+ * @typedef {import('./types/Options').Options} Options
  */
 
 const criteriaMap = new Map(allCriteria.map(criteria => [criteria.name, criteria]));
@@ -23,11 +24,12 @@ function getOffers(opportunity) {
 /**
  * @param {Criteria} criteria
  * @param {Opportunity} opportunity
+ * @param {Options} options
  */
-function filterRelevantOffers(criteria, opportunity) {
+function filterRelevantOffers(criteria, opportunity, options) {
   const offers = getOffers(opportunity);
   return criteria.offerConstraints
-    .reduce((relevantOffers, [, test]) => relevantOffers.filter(offer => test(offer, opportunity)), offers);
+    .reduce((relevantOffers, [, test]) => relevantOffers.filter(offer => test(offer, opportunity, options)), offers);
 }
 
 /**
@@ -40,21 +42,22 @@ function filterRelevantOffers(criteria, opportunity) {
  *
  * @param {Criteria} criteria
  * @param {Opportunity} opportunity
+ * @param {Options} options
  */
-function testMatch(criteria, opportunity) {
+function testMatch(criteria, opportunity, options) {
   // Array of unmetOpportunityConstraints labels
   const unmetOpportunityConstraints = criteria.opportunityConstraints
-    .filter(([, test]) => !test(opportunity))
+    .filter(([, test]) => !test(opportunity, options))
     .map(([name]) => name);
 
   // Array of Offers that match the criteria
-  const relevantOffers = filterRelevantOffers(criteria, opportunity);
+  const relevantOffers = filterRelevantOffers(criteria, opportunity, options);
 
   // Only check for unmetOfferConstraints if there are no matching offers
   // Array of unmetOfferConstraints labels
   const offers = getOffers(opportunity);
   const unmetOfferConstraints = relevantOffers.length > 0 ? [] : criteria.offerConstraints
-    .filter(([, test]) => !offers.some(offer => test(offer, opportunity)))
+    .filter(([, test]) => !offers.some(offer => test(offer, opportunity, options)))
     .map(([name]) => name);
 
   // Boolean: does this opportunity match the criteria?
@@ -72,10 +75,11 @@ function testMatch(criteria, opportunity) {
 /**
  * @param {string} criteriaName
  * @param {Opportunity} opportunity
+ * @param {Options} options
  */
-function getRelevantOffers(criteriaName, opportunity) {
+function getRelevantOffers(criteriaName, opportunity, options) {
   if (!criteriaMap.has(criteriaName)) throw new Error('Invalid criteria name');
-  return filterRelevantOffers(criteriaMap.get(criteriaName), opportunity);
+  return filterRelevantOffers(criteriaMap.get(criteriaName), opportunity, options);
 }
 
 module.exports = {

--- a/packages/test-interface-criteria/src/types/Criteria.d.ts
+++ b/packages/test-interface-criteria/src/types/Criteria.d.ts
@@ -1,9 +1,10 @@
 import { Opportunity } from './Opportunity';
 import { Offer } from './Offer';
+import { Options } from './Options';
 
-export type OpportunityConstraint = (opportunity: Opportunity) => boolean;
+export type OpportunityConstraint = (opportunity: Opportunity, options?: Options) => boolean;
 
-export type OfferConstraint = (offer: Offer, opportunity: Opportunity) => boolean;
+export type OfferConstraint = (offer: Offer, opportunity: Opportunity, options?: Options) => boolean;
 
 export type Criteria = {
   name: string,

--- a/packages/test-interface-criteria/src/types/Options.d.ts
+++ b/packages/test-interface-criteria/src/types/Options.d.ts
@@ -1,0 +1,3 @@
+export type Options = {
+  harvestStartTime: Date,
+};


### PR DESCRIPTION
Fixes these issues:
- `IndividualFacilityUse` is not allowed `Slot` with `remainingUses` of greater than one, which causes issues with "multiple" opportunity tests (https://github.com/openactive/openactive-test-suite/issues/236)
- Additionally the current time is referenced in test-interface-criteria which makes the bucket allocation inconsistent between harvesting and the test run.