### PR TITLE
Coverage/access pass barcode seller

### DIFF
--- a/packages/openactive-integration-tests/config/default.json
+++ b/packages/openactive-integration-tests/config/default.json
@@ -42,7 +42,7 @@
     "additional-details-capture": null,
     "access-code": true,
     "access-pass-image": true,
-    "access-pass-barcode-seller-provided": null,
+    "access-pass-barcode-seller-provided": true,
     "access-pass-barcode-broker-provided": null,
     "reseller-broker": null,
     "reseller-broker-tax-calculation": null,

--- a/packages/openactive-integration-tests/test/features/access/access-pass-barcode-seller-provided/README.md
+++ b/packages/openactive-integration-tests/test/features/access/access-pass-barcode-seller-provided/README.md
@@ -7,9 +7,28 @@ Support for accessPass provided by the Seller, in the form of a barcode
 https://www.openactive.io/open-booking-api/EditorsDraft/#extension-point-for-barcode-based-access-control
 
 Coverage Status: **none**
+### Test prerequisites
+Opportunities that match the following criteria must exist in the booking system (for each configured `bookableOpportunityTypesInScope`) for the configured primary Seller in order to use `useRandomOpportunities: true`. Alternatively the following `testOpportunityCriteria` values must be supported by the [test interface](https://openactive.io/test-interface/) of the booking system for `useRandomOpportunities: false`.
 
+[TestOpportunityBookable](https://openactive.io/test-interface#TestOpportunityBookable) x4
 
 *Note the test coverage for this feature is currently nonexistent. The test suite does not yet include non-stubbed tests for this feature.*
 
+
+## 'Implemented' tests
+
+Update `default.json` within `packages/openactive-integration-tests/config/` as follows to enable 'Implemented' testing for this feature:
+
+```json
+"implementedFeatures": {
+  ...
+  "access-pass-barcode-seller-provided": true,
+  ...
+}
+```
+
+| Identifier | Name | Description | Prerequisites per Opportunity Type |
+|------------|------|-------------|---------------|
+| [access-barcode-seller](./implemented/access-barcode-seller-test.js) | Successful booking with access barcode from seller. | Access pass contains barcode returned for B request from seller. | [TestOpportunityBookable](https://openactive.io/test-interface#TestOpportunityBookable) x4 |
 
 

--- a/packages/openactive-integration-tests/test/features/access/access-pass-barcode-seller-provided/implemented/access-barcode-seller-test.js
+++ b/packages/openactive-integration-tests/test/features/access/access-pass-barcode-seller-provided/implemented/access-barcode-seller-test.js
@@ -1,0 +1,91 @@
+/* eslint-disable no-unused-vars */
+const chakram = require('chakram');
+const chai = require('chai');
+chai.use(require('chai-arrays'));
+
+const { FeatureHelper } = require('../../../../helpers/feature-helper');
+const { GetMatch, C1, C2, B } = require('../../../../shared-behaviours');
+
+/* eslint-enable no-unused-vars */
+
+FeatureHelper.describeFeature(module, {
+  testCategory: 'access',
+  testFeature: 'access-pass-barcode-seller-provided',
+  testFeatureImplemented: true,
+  testIdentifier: 'access-barcode-seller',
+  testName: 'Successful booking with access barcode from seller.',
+  testDescription: 'Access pass contains barcode returned for B request from seller.',
+  // The primary opportunity criteria to use for the primary OrderItem under test
+  testOpportunityCriteria: 'TestOpportunityBookable',
+  // The secondary opportunity criteria to use for multiple OrderItem tests
+  controlOpportunityCriteria: 'TestOpportunityBookable',
+},
+function (configuration, orderItemCriteria, featureIsImplemented, logger, state, flow) {
+  beforeAll(async function () {
+    await state.fetchOpportunities(orderItemCriteria);
+
+    return chakram.wait();
+  });
+
+  afterAll(async function () {
+    await state.deleteOrder();
+    return chakram.wait();
+  });
+
+  describe('Get Opportunity Feed Items', function () {
+    (new GetMatch({
+      state, flow, logger, orderItemCriteria,
+    }))
+      .beforeSetup()
+      .successChecks()
+      .validationTests();
+  });
+
+  describe('C1', function () {
+    (new C1({
+      state, flow, logger,
+    }))
+      .beforeSetup()
+      .successChecks()
+      .validationTests();
+  });
+
+  describe('C2', function () {
+    (new C2({
+      state, flow, logger,
+    }))
+      .beforeSetup()
+      .successChecks()
+      .validationTests();
+  });
+
+  describe('B', function () {
+    (new B({
+      state, flow, logger,
+    }))
+      .beforeSetup()
+      .successChecks()
+      .validationTests();
+
+    // TODO: refactor to check every element.
+    it('Response should include Barcode accessPass with url, text and codeType field', () => {
+      // @ts-expect-error chai-arrays doesn't have a types package
+      chai.expect(state.bResponse.body.orderedItem).to.be.array();
+
+      state.bResponse.body.orderedItem.forEach((orderItem, orderItemIndex) => {
+        // @ts-expect-error chai-arrays doesn't have a types package
+        chai.expect(orderItem.accessPass).to.be.array();
+
+        orderItem.accessPass.forEach((accessPass, accessPassIndex) => {
+          // Both Image and Barcode contain url, but Barcode contains 2 more field.
+          chai.expect(state.bResponse.body).to.have.nested.property(`orderedItem[${orderItemIndex}].accessPass[${accessPassIndex}].url`).that.is.a('string');
+
+          if (accessPass['@type'] === 'Barcode') {
+            chai.expect(state.bResponse.body).to.have.nested.property(`orderedItem[${orderItemIndex}].accessPass[${accessPassIndex}].text`).that.is.a('string');
+            chai.expect(state.bResponse.body).to.have.nested.property(`orderedItem[${orderItemIndex}].accessPass[${accessPassIndex}].beta:codeType`).that.is.a('string');
+          }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Test for access pass via barcode from seller
- B response will contain both Image and Barcode objects in access pass array and for both of them we check that it contains url, and for Barcode additionally check text and codeType 
(@nickevansuk note documentation is bit off here https://openactive.io/open-booking-api/EditorsDraft/#extension-point-for-barcode-based-access-control it says that field is called: "bookwhen:codeType", while it actually returns "beta:codeType")