### PR TITLE
refactor: Add describeRunAndCheckIsValid() function for FlowStages which are expected to error

### DIFF
--- a/packages/openactive-integration-tests/test/features/core/agent-broker/implemented/customer-not-included-test.js
+++ b/packages/openactive-integration-tests/test/features/core/agent-broker/implemented/customer-not-included-test.js
@@ -1,12 +1,3 @@
-// /* eslint-disable no-unused-vars */
-// const chakram = require('chakram');
-// const { FeatureHelper } = require('../../../../helpers/feature-helper');
-// const { GetMatch, C1, C2, B } = require('../../../../shared-behaviours');
-// const { FlowHelper } = require('../../../../helpers/flow-helper');
-// const { RequestState } = require('../../../../helpers/request-state');
-// const { itShouldReturnAnOpenBookingError } = require('../../../../shared-behaviours/errors');
-
-// /* eslint-enable no-unused-vars */
 const { FeatureHelper } = require('../../../../helpers/feature-helper');
 const { FlowStageRecipes, FlowStageUtils } = require('../../../../helpers/flow-stages');
 const { itShouldReturnAnOpenBookingError } = require('../../../../shared-behaviours/errors');

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/b.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/b.js
@@ -35,7 +35,7 @@ async function runB({ templateRef, uuid, sellerId, orderItems, totalPaymentDue, 
     totalPaymentDue,
     orderProposalVersion,
   };
-  const response = await requestHelper.putOrder(uuid, params, templateRef);
+  const response = await requestHelper.putOrder(uuid, params, null, templateRef);
   const bookingSystemOrder = response.body;
 
   return {

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/c1.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/c1.js
@@ -30,7 +30,7 @@ async function runC1({ templateRef, uuid, sellerId, orderItems, requestHelper })
     sellerId,
     orderItems,
   };
-  const response = await requestHelper.putOrderQuoteTemplate(uuid, params, templateRef);
+  const response = await requestHelper.putOrderQuoteTemplate(uuid, params, null, templateRef);
   const bookingSystemOrder = response.body;
 
   return {

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/c2.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/c2.js
@@ -30,7 +30,7 @@ async function runC2({ templateRef, uuid, sellerId, orderItems, requestHelper })
     sellerId,
     orderItems,
   };
-  const response = await requestHelper.putOrderQuote(uuid, params, templateRef);
+  const response = await requestHelper.putOrderQuote(uuid, params, null, templateRef);
   const bookingSystemOrder = response.body;
 
   return {

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
@@ -71,7 +71,11 @@ const FlowStageRecipes = {
     });
 
     return {
-      c1, c2, b, requestHelper,
+      requestHelper,
+      fetchOpportunities,
+      c1,
+      c2,
+      b,
     };
   },
 };

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
@@ -8,6 +8,9 @@ const { FlowStageUtils } = require('./flow-stage-utils');
 /**
  * @typedef {import('../request-state').OpportunityCriteria} OpportunityCriteria
  * @typedef {import('../logger').BaseLoggerType} BaseLoggerType
+ * @typedef {import('../../templates/c1-req').C1ReqTemplateRef} C1ReqTemplateRef
+ * @typedef {import('../../templates/c2-req').C2ReqTemplateRef} C2ReqTemplateRef
+ * @typedef {import('../../templates/b-req').BReqTemplateRef} BReqTemplateRef
  */
 
 const FlowStageRecipes = {
@@ -22,8 +25,12 @@ const FlowStageRecipes = {
    *
    * @param {OpportunityCriteria[]} orderItemCriteriaList
    * @param {BaseLoggerType} logger
+   * @param {object} [options]
+   * @param {C1ReqTemplateRef | null} [options.c1ReqTemplateRef]
+   * @param {C2ReqTemplateRef | null} [options.c2ReqTemplateRef]
+   * @param {BReqTemplateRef | null} [options.bReqTemplateRef]
    */
-  initialiseSimpleC1C2BFlow(orderItemCriteriaList, logger) {
+  initialiseSimpleC1C2BFlow(orderItemCriteriaList, logger, { c1ReqTemplateRef = null, c2ReqTemplateRef = null, bReqTemplateRef = null } = {}) {
     const requestHelper = new RequestHelper(logger);
 
     // ## Initiate Flow Stages
@@ -34,6 +41,7 @@ const FlowStageRecipes = {
     });
     const c1 = new C1FlowStage({
       ...defaultFlowStageParams,
+      templateRef: c1ReqTemplateRef,
       prerequisite: fetchOpportunities,
       getInput: () => ({
         orderItems: fetchOpportunities.getOutput().orderItems,
@@ -41,6 +49,7 @@ const FlowStageRecipes = {
     });
     const c2 = new C2FlowStage({
       ...defaultFlowStageParams,
+      templateRef: c2ReqTemplateRef,
       prerequisite: c1,
       getInput: () => ({
         orderItems: fetchOpportunities.getOutput().orderItems,
@@ -48,6 +57,7 @@ const FlowStageRecipes = {
     });
     const b = new BFlowStage({
       ...defaultFlowStageParams,
+      templateRef: bReqTemplateRef,
       prerequisite: c2,
       getInput: () => ({
         orderItems: fetchOpportunities.getOutput().orderItems,

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
@@ -1,0 +1,66 @@
+const RequestHelper = require('../request-helper');
+const { BFlowStage } = require('./b');
+const { C1FlowStage } = require('./c1');
+const { C2FlowStage } = require('./c2');
+const { FetchOpportunitiesFlowStage } = require('./fetch-opportunities');
+const { FlowStageUtils } = require('./flow-stage-utils');
+
+/**
+ * @typedef {import('../request-state').OpportunityCriteria} OpportunityCriteria
+ * @typedef {import('../logger').BaseLoggerType} BaseLoggerType
+ */
+
+const FlowStageRecipes = {
+  /**
+   * Initialise Flow Stages for a simple FetchOpportunities -> C1 -> C2 -> B flow.
+   *
+   * Rather than setting custom input for each stage, the input is just fed automatically
+   * from the output of previous stages.
+   *
+   * DO NOT USE THIS FUNCTION if you want to use custom inputs for each stage (e.g.
+   * to create erroneous requests).
+   *
+   * @param {OpportunityCriteria[]} orderItemCriteriaList
+   * @param {BaseLoggerType} logger
+   */
+  initialiseSimpleC1C2BFlow(orderItemCriteriaList, logger) {
+    const requestHelper = new RequestHelper(logger);
+
+    // ## Initiate Flow Stages
+    const defaultFlowStageParams = FlowStageUtils.createDefaultFlowStageParams({ requestHelper, logger });
+    const fetchOpportunities = new FetchOpportunitiesFlowStage({
+      ...defaultFlowStageParams,
+      orderItemCriteriaList,
+    });
+    const c1 = new C1FlowStage({
+      ...defaultFlowStageParams,
+      prerequisite: fetchOpportunities,
+      getInput: () => ({
+        orderItems: fetchOpportunities.getOutput().orderItems,
+      }),
+    });
+    const c2 = new C2FlowStage({
+      ...defaultFlowStageParams,
+      prerequisite: c1,
+      getInput: () => ({
+        orderItems: fetchOpportunities.getOutput().orderItems,
+      }),
+    });
+    const b = new BFlowStage({
+      ...defaultFlowStageParams,
+      prerequisite: c2,
+      getInput: () => ({
+        orderItems: fetchOpportunities.getOutput().orderItems,
+        totalPaymentDue: c2.getOutput().totalPaymentDue,
+      }),
+    });
+
+    return {
+      c1, c2, b, requestHelper,
+    };
+  },
+};
+
+module.exports = {
+  FlowStageRecipes,
+};

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
@@ -13,6 +13,14 @@ const { FlowStageUtils } = require('./flow-stage-utils');
  * @typedef {import('../../templates/b-req').BReqTemplateRef} BReqTemplateRef
  */
 
+/**
+ * @typedef {{
+ *   c1ReqTemplateRef?: C1ReqTemplateRef | null,
+ *   c2ReqTemplateRef?: C2ReqTemplateRef | null,
+ *   bReqTemplateRef?: BReqTemplateRef | null,
+ * }} OptionalC1C2BReqTemplateRefs
+ */
+
 const FlowStageRecipes = {
   /**
    * Initialise Flow Stages for a simple FetchOpportunities -> C1 -> C2 -> B flow.
@@ -25,10 +33,7 @@ const FlowStageRecipes = {
    *
    * @param {OpportunityCriteria[]} orderItemCriteriaList
    * @param {BaseLoggerType} logger
-   * @param {object} [options]
-   * @param {C1ReqTemplateRef | null} [options.c1ReqTemplateRef]
-   * @param {C2ReqTemplateRef | null} [options.c2ReqTemplateRef]
-   * @param {BReqTemplateRef | null} [options.bReqTemplateRef]
+   * @param {OptionalC1C2BReqTemplateRefs} [options]
    */
   initialiseSimpleC1C2BFlow(orderItemCriteriaList, logger, { c1ReqTemplateRef = null, c2ReqTemplateRef = null, bReqTemplateRef = null } = {}) {
     const requestHelper = new RequestHelper(logger);

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/index.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/index.js
@@ -2,6 +2,7 @@ const { BFlowStage } = require('./b');
 const { C1FlowStage } = require('./c1');
 const { C2FlowStage } = require('./c2');
 const { FetchOpportunitiesFlowStage } = require('./fetch-opportunities');
+const { FlowStageRecipes } = require('./flow-stage-recipes');
 const { FlowStageUtils } = require('./flow-stage-utils');
 const { OrderFeedUpdateFlowStageUtils, OrderFeedUpdateListener, OrderFeedUpdateCollector } = require('./order-feed-update');
 const { PFlowStage } = require('./p');
@@ -18,5 +19,6 @@ module.exports = {
   OrderFeedUpdateListener,
   OrderFeedUpdateCollector,
   TestInterfaceActionFlowStage,
+  FlowStageRecipes,
   FlowStageUtils,
 };


### PR DESCRIPTION
Also, fix use of template for c1,c2,b, which have not taken into account new brokerRole positional arg in RequestHelper

-----

Depends on https://github.com/openactive/openactive-test-suite/pull/285

In order to test that this worked, I tried it out on an existing test, `customer-not-included`. It works. Hooray.