### PR TITLE
fix(flow-stages): B requires `prepayment` in its Input

### DIFF
--- a/packages/openactive-integration-tests/test/features/approval/minimal-proposal/implemented/accept-proposal-book-test.js
+++ b/packages/openactive-integration-tests/test/features/approval/minimal-proposal/implemented/accept-proposal-book-test.js
@@ -98,6 +98,7 @@ FeatureHelper.describeFeature(module, {
       orderItems: fetchOpportunities.getOutput().orderItems,
       totalPaymentDue: p.getOutput().totalPaymentDue,
       orderProposalVersion: p.getOutput().orderProposalVersion,
+      prepayment: p.getOutput().prepayment,
     }),
   });
 

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/b.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/b.js
@@ -13,8 +13,8 @@ const { FlowStageUtils } = require('./flow-stage-utils');
  */
 
 /**
- * @typedef {Required<Pick<FlowStageOutput, 'orderItems' | 'totalPaymentDue'>>
- *   & Partial<Pick<FlowStageOutput, 'orderProposalVersion' | 'prepayment'>>} Input
+ * @typedef {Required<Pick<FlowStageOutput, 'orderItems' | 'totalPaymentDue' | 'prepayment'>>
+ *   & Partial<Pick<FlowStageOutput, 'orderProposalVersion'>>} Input
  * @typedef {Required<Pick<FlowStageOutput, 'httpResponse' | 'totalPaymentDue' | 'prepayment' | 'orderId'>>} Output
  */
 


### PR DESCRIPTION
This means that it is no longer possible to accidentally exclude it in a new test (which would make random prepayment=unavailable tests fail

------

I did this because I notice that some of the existing PRs will randomly fail and should get a TS error