### PR TITLE
feat: Delete check for proposal

### DIFF
--- a/packages/openactive-integration-tests/test/features/approval/minimal-proposal/implemented/accept-proposal-book-test.js
+++ b/packages/openactive-integration-tests/test/features/approval/minimal-proposal/implemented/accept-proposal-book-test.js
@@ -1,16 +1,9 @@
 const { expect } = require('chai');
 const { FeatureHelper } = require('../../../../helpers/feature-helper');
 const {
-  FetchOpportunitiesFlowStage,
-  C1FlowStage,
-  C2FlowStage,
   FlowStageUtils,
-  PFlowStage,
-  TestInterfaceActionFlowStage,
-  OrderFeedUpdateFlowStageUtils,
-  BFlowStage,
+  FlowStageRecipes,
 } = require('../../../../helpers/flow-stages');
-const RequestHelper = require('../../../../helpers/request-helper');
 
 /**
  * @typedef {import('chakram').ChakramResponse} ChakramResponse
@@ -42,64 +35,17 @@ FeatureHelper.describeFeature(module, {
   skipBookingFlows: ['OpenBookingSimpleFlow'],
 },
 (configuration, orderItemCriteriaList, featureIsImplemented, logger) => {
-  const requestHelper = new RequestHelper(logger);
-
-  // ## Initiate Flow Stages
-  const defaultFlowStageParams = FlowStageUtils.createDefaultFlowStageParams({ requestHelper, logger });
-  const fetchOpportunities = new FetchOpportunitiesFlowStage({
-    ...defaultFlowStageParams,
+  const { fetchOpportunities, c1, c2, defaultFlowStageParams } = FlowStageRecipes.initialiseSimpleC1C2Flow(
     orderItemCriteriaList,
-  });
-  const c1 = new C1FlowStage({
-    ...defaultFlowStageParams,
-    prerequisite: fetchOpportunities,
-    getInput: () => ({
-      orderItems: fetchOpportunities.getOutput().orderItems,
-    }),
-  });
-  const c2 = new C2FlowStage({
-    ...defaultFlowStageParams,
-    prerequisite: c1,
-    getInput: () => ({
-      orderItems: fetchOpportunities.getOutput().orderItems,
-    }),
-  });
-  const p = new PFlowStage({
-    ...defaultFlowStageParams,
+    logger,
+  );
+  const bookRecipe = FlowStageRecipes.bookApproval(orderItemCriteriaList, defaultFlowStageParams, {
     prerequisite: c2,
-    getInput: () => ({
+    getFirstStageInput: () => ({
       orderItems: fetchOpportunities.getOutput().orderItems,
       totalPaymentDue: c2.getOutput().totalPaymentDue,
       prepayment: c2.getOutput().prepayment,
-    }),
-  });
-  const [simulateSellerApproval, orderFeedUpdate] = OrderFeedUpdateFlowStageUtils.wrap({
-    // FlowStage that is getting wrapped
-    wrappedStageFn: prerequisite => (new TestInterfaceActionFlowStage({
-      ...defaultFlowStageParams,
-      testName: 'Simulate Seller Approval (Test Interface Action)',
-      prerequisite,
-      createActionFn: () => ({
-        type: 'test:SellerAcceptOrderProposalSimulateAction',
-        objectType: 'OrderProposal',
-        objectId: p.getOutput().orderId,
-      }),
-    })),
-    // Params for the Order Feed Update stages
-    orderFeedUpdateParams: {
-      ...defaultFlowStageParams,
-      prerequisite: p,
-      testName: 'Order Feed Update (after Simulate Seller Approval)',
-    },
-  });
-  const b = new BFlowStage({
-    ...defaultFlowStageParams,
-    prerequisite: orderFeedUpdate,
-    getInput: () => ({
-      orderItems: fetchOpportunities.getOutput().orderItems,
-      totalPaymentDue: p.getOutput().totalPaymentDue,
-      orderProposalVersion: p.getOutput().orderProposalVersion,
-      prepayment: p.getOutput().prepayment,
+      positionOrderIntakeFormMap: c1.getOutput().positionOrderIntakeFormMap,
     }),
   });
 
@@ -112,24 +58,25 @@ FeatureHelper.describeFeature(module, {
   FlowStageUtils.describeRunAndCheckIsSuccessfulAndValid(c2, () => {
     itShouldReturnOrderRequiresApprovalTrue(() => c2.getOutput().httpResponse);
   });
-  FlowStageUtils.describeRunAndCheckIsSuccessfulAndValid(p, () => {
+  FlowStageUtils.describeRunAndCheckIsSuccessfulAndValid(bookRecipe, () => {
     // TODO does validator already check that orderProposalVersion is of form {orderId}/versions/{versionUuid}?
     it('should include an orderProposalVersion, of the form {orderId}/versions/{versionUuid}', () => {
       const { uuid } = defaultFlowStageParams;
-      expect(p.getOutput().httpResponse.body).to.have.property('orderProposalVersion')
+      expect(bookRecipe.p.getOutput().httpResponse.body).to.have.property('orderProposalVersion')
         .which.matches(RegExp(`${uuid}/versions/.+`));
     });
     // TODO does validator check that orderItemStatus is https://openactive.io/OrderItemProposed?
     // TODO does validator check that full Seller details are included in the seller response?
-  });
-  FlowStageUtils.describeRunAndCheckIsSuccessfulAndValid(simulateSellerApproval);
-  FlowStageUtils.describeRunAndCheckIsSuccessfulAndValid(orderFeedUpdate, () => {
     it('should have orderProposalStatus: SellerAccepted', () => {
-      expect(orderFeedUpdate.getOutput().httpResponse.body).to.have.nested.property('data.orderProposalStatus', 'https://openactive.io/SellerAccepted');
+      expect(bookRecipe.orderFeedUpdateCollector.getOutput().httpResponse.body)
+        .to.have.nested.property('data.orderProposalStatus', 'https://openactive.io/SellerAccepted');
     });
     it('should have orderProposalVersion same as that returned by P (i.e. an amendment hasn\'t occurred)', () => {
-      expect(orderFeedUpdate.getOutput().httpResponse.body).to.have.nested.property('data.orderProposalVersion', p.getOutput().orderProposalVersion);
+      expect(bookRecipe.orderFeedUpdateCollector.getOutput().httpResponse.body)
+        .to.have.nested.property('data.orderProposalVersion', bookRecipe.p.getOutput().orderProposalVersion);
+    });
+    it('should have deleted the OrderProposal after B', () => {
+      expect(bookRecipe.orderFeedUpdateAfterDeleteProposal.getOutput().httpResponse.body).to.have.property('state', 'deleted');
     });
   });
-  FlowStageUtils.describeRunAndCheckIsSuccessfulAndValid(b);
 });

--- a/packages/openactive-integration-tests/test/features/payment/common.js
+++ b/packages/openactive-integration-tests/test/features/payment/common.js
@@ -73,6 +73,9 @@ function successTests(expectedPrepayment, bookReqTemplateRef) {
     FlowStageUtils.describeRunAndCheckIsSuccessfulAndValid(bookRecipe, () => {
       if (bookRecipe.p) {
         itShouldHavePrepayment(expectedPrepayment, () => bookRecipe.p.getOutput().httpResponse.body);
+        it('should have state: deleted', () => {
+          expect(bookRecipe.orderFeedUpdateAfterDelete.getOutput().httpResponse.body.state).to.equal('deleted');
+        });
       }
       itShouldHavePrepayment(expectedPrepayment, () => bookRecipe.b.getOutput().httpResponse.body);
     });

--- a/packages/openactive-integration-tests/test/features/payment/common.js
+++ b/packages/openactive-integration-tests/test/features/payment/common.js
@@ -73,9 +73,6 @@ function successTests(expectedPrepayment, bookReqTemplateRef) {
     FlowStageUtils.describeRunAndCheckIsSuccessfulAndValid(bookRecipe, () => {
       if (bookRecipe.p) {
         itShouldHavePrepayment(expectedPrepayment, () => bookRecipe.p.getOutput().httpResponse.body);
-        it('should have state: deleted', () => {
-          expect(bookRecipe.orderFeedUpdateAfterDelete.getOutput().httpResponse.body.state).to.equal('deleted');
-        });
       }
       itShouldHavePrepayment(expectedPrepayment, () => bookRecipe.b.getOutput().httpResponse.body);
     });

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/book-recipe.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/book-recipe.js
@@ -18,15 +18,15 @@ class BookRecipe {
    * @param {TestInterfaceActionFlowStageType | null} [args.simulateSellerApproval]
    * @param {OrderFeedUpdateCollectorType | null} [args.orderFeedUpdateCollector]
    * @param {BFlowStageType | PFlowStageType} args.firstStage
-   * @param {OrderFeedUpdateCollectorType | null} [args.orderFeedUpdateAfterDelete]
+   * @param {OrderFeedUpdateCollectorType | null} [args.orderFeedUpdateAfterDeleteProposal]
    */
-  constructor({ b, p, simulateSellerApproval, orderFeedUpdateCollector, firstStage, orderFeedUpdateAfterDelete }) {
+  constructor({ b, p, simulateSellerApproval, orderFeedUpdateCollector, firstStage, orderFeedUpdateAfterDeleteProposal }) {
     this.b = b;
     this.p = p;
     this.simulateSellerApproval = simulateSellerApproval;
     this.orderFeedUpdateCollector = orderFeedUpdateCollector;
     this.firstStage = firstStage;
-    this.orderFeedUpdateAfterDelete = orderFeedUpdateAfterDelete;
+    this.orderFeedUpdateAfterDeleteProposal = orderFeedUpdateAfterDeleteProposal;
   }
 }
 

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/book-recipe.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/book-recipe.js
@@ -18,13 +18,15 @@ class BookRecipe {
    * @param {TestInterfaceActionFlowStageType | null} [args.simulateSellerApproval]
    * @param {OrderFeedUpdateCollectorType | null} [args.orderFeedUpdateCollector]
    * @param {BFlowStageType | PFlowStageType} args.firstStage
+   * @param {OrderFeedUpdateCollectorType | null} [args.orderFeedUpdateAfterDelete]
    */
-  constructor({ b, p, simulateSellerApproval, orderFeedUpdateCollector, firstStage }) {
+  constructor({ b, p, simulateSellerApproval, orderFeedUpdateCollector, firstStage, orderFeedUpdateAfterDelete }) {
     this.b = b;
     this.p = p;
     this.simulateSellerApproval = simulateSellerApproval;
     this.orderFeedUpdateCollector = orderFeedUpdateCollector;
     this.firstStage = firstStage;
+    this.orderFeedUpdateAfterDelete = orderFeedUpdateAfterDelete;
   }
 }
 

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
@@ -34,6 +34,19 @@ const { TestInterfaceActionFlowStage } = require('./test-interface-action');
  * }} InitialiseSimpleC1C2BookFlowOptions
  */
 
+/**
+ * @typedef {object} BookRecipeArgs
+ * @property {UnknownFlowStageType} prerequisite
+ * @property {string | null} [brokerRole]
+ * @property {AccessPassItem[] | null} [accessPass]
+ * @property {PReqTemplateRef | null} [firstStageReqTemplateRef] Reference for the template which will be used
+ *   for the first stage - B or P.
+ *   Note that the template ref is a `PReqTemplateRef`. That's because the only difference between `PReqTemplateRef`
+ *   and `BReqTemplateRef` is that the latter includes the `afterP` template which is exclusively used for the B at
+ *   the end of approval flow. Therefore, regardless of flow, the first stage will never use `afterP`.
+ * @property {() => import('./p').Input} getFirstStageInput Input for the first flow stage - B or P.
+ */
+
 const FlowStageRecipes = {
   /**
    * Initialise Flow Stages for a simple FetchOpportunities -> C1 -> C2 -> Book (*) flow.
@@ -141,10 +154,15 @@ const FlowStageRecipes = {
     };
   },
   /**
-   * A Recipe to either run B or P -> OrderFeedUpdate[SellerAcceptOrderProposalSimulateAction] -> B depending on the flow.
+   * A Recipe to either run B or P -> Approve -> B depending on the flow.
    *
    * - If in Simple Booking Flow, the recipe will just return B
-   * - If in Approval Flow, the recipe will return P -> OrderFeedUpdate[SellerAcceptOrderProposalSimulateAction] -> B
+   * - If in Approval Flow, the recipe will return
+   *   1. P
+   *   2. SellerAcceptOrderProposalSimulateAction
+   *     a. Await OrderFeedUpdate, which should return approved Proposal
+   *   3. B
+   *     a. Await OrderFeedUpdate, which should delete Proposal
    *
    * This therefore represents the Book step of either flow.
    *
@@ -157,87 +175,34 @@ const FlowStageRecipes = {
    *
    * @param {OpportunityCriteria[]} orderItemCriteriaList
    * @param {ReturnType<typeof FlowStageUtils.createDefaultFlowStageParams>} defaultFlowStageParams
-   * @param {object} args
-   * @param {UnknownFlowStageType} args.prerequisite
-   * @param {string | null} [args.brokerRole]
-   * @param {AccessPassItem[] | null} [args.accessPass]
-   * @param {PReqTemplateRef | null} [args.firstStageReqTemplateRef] Reference for the template which will be used
-   *   for the first stage - B or P.
-   *   Note that the template ref is a `PReqTemplateRef`. That's because the only difference between `PReqTemplateRef`
-   *   and `BReqTemplateRef` is that the latter includes the `afterP` template which is exclusively used for the B at
-   *   the end of approval flow. Therefore, regardless of flow, the first stage will never use `afterP`.
-   * @param {() => import('./p').Input} args.getFirstStageInput Input for the first flow stage - B or P.
+   * @param {BookRecipeArgs} bookRecipeArgs
    * @returns {BookRecipe}
    */
-  book(orderItemCriteriaList, defaultFlowStageParams, {
+  book(orderItemCriteriaList, defaultFlowStageParams, bookRecipeArgs) {
+    const doUseApprovalFlow = orderItemCriteriaList.some(orderItemCriteria => (
+      orderItemCriteria.bookingFlow === 'OpenBookingApprovalFlow'));
+    if (doUseApprovalFlow) {
+      return FlowStageRecipes.bookApproval(orderItemCriteriaList, defaultFlowStageParams, bookRecipeArgs);
+    }
+    return FlowStageRecipes.bookSimple(orderItemCriteriaList, defaultFlowStageParams, bookRecipeArgs);
+  },
+  /**
+   * Create a BookRecipe explicitly for the Simple Booking Flow.
+   *
+   * See: FlowStageRecipes.book for more info
+   *
+   * @param {OpportunityCriteria[]} orderItemCriteriaList
+   * @param {ReturnType<typeof FlowStageUtils.createDefaultFlowStageParams>} defaultFlowStageParams
+   * @param {BookRecipeArgs} args
+   * @returns {BookRecipe}
+   */
+  bookSimple(orderItemCriteriaList, defaultFlowStageParams, {
     prerequisite,
     brokerRole = null,
     accessPass = null,
     firstStageReqTemplateRef = null,
     getFirstStageInput,
   }) {
-    const doUseApprovalFlow = orderItemCriteriaList.some(orderItemCriteria => (
-      orderItemCriteria.bookingFlow === 'OpenBookingApprovalFlow'));
-    if (doUseApprovalFlow) {
-      const p = new PFlowStage({
-        ...defaultFlowStageParams,
-        prerequisite,
-        templateRef: firstStageReqTemplateRef,
-        brokerRole,
-        accessPass,
-        getInput: getFirstStageInput,
-      });
-      const [simulateSellerApproval, orderFeedUpdateCollector] = OrderFeedUpdateFlowStageUtils.wrap({
-        wrappedStageFn: orderFeedUpdateListener => (new TestInterfaceActionFlowStage({
-          ...defaultFlowStageParams,
-          testName: 'Simulate Seller Approval (Test Interface Action)',
-          prerequisite: orderFeedUpdateListener,
-          createActionFn: () => ({
-            type: 'test:SellerAcceptOrderProposalSimulateAction',
-            objectType: 'OrderProposal',
-            objectId: p.getOutput().orderId,
-          }),
-        })),
-        orderFeedUpdateParams: {
-          ...defaultFlowStageParams,
-          prerequisite: p,
-          testName: 'Order Feed Update (after Simulate Seller Approval)',
-        },
-      });
-
-      const [b, orderFeedUpdateAfterDelete] = OrderFeedUpdateFlowStageUtils.wrap({
-        wrappedStageFn: orderFeedUpdateListener => (new BFlowStage({
-          ...defaultFlowStageParams,
-          prerequisite: orderFeedUpdateListener,
-          templateRef: 'afterP',
-          /* note that brokerRole & accessPass don't need to be passed. This is the minimal "B after P" call which
-          just presents `orderProposalVersion` and optional payment details */
-          getInput() {
-            const firstStageInput = getFirstStageInput();
-            return {
-              orderItems: firstStageInput.orderItems,
-              totalPaymentDue: p.getOutput().totalPaymentDue,
-              orderProposalVersion: p.getOutput().orderProposalVersion,
-              prepayment: p.getOutput().prepayment,
-            };
-          },
-        })),
-        orderFeedUpdateParams: {
-          ...defaultFlowStageParams,
-          prerequisite: orderFeedUpdateCollector,
-          testName: 'Orders Feed (after B)',
-        },
-      });
-
-      return new BookRecipe({
-        firstStage: p,
-        p,
-        simulateSellerApproval,
-        orderFeedUpdateCollector,
-        b,
-        orderFeedUpdateAfterDelete,
-      });
-    }
     const b = new BFlowStage({
       ...defaultFlowStageParams,
       prerequisite,
@@ -249,6 +214,82 @@ const FlowStageRecipes = {
     return new BookRecipe({
       firstStage: b,
       b,
+    });
+  },
+  /**
+   * Create a BookRecipe explicitly for the Approval Flow.
+   *
+   * See: FlowStageRecipes.book for more info
+   *
+   * @param {OpportunityCriteria[]} orderItemCriteriaList
+   * @param {ReturnType<typeof FlowStageUtils.createDefaultFlowStageParams>} defaultFlowStageParams
+   * @param {BookRecipeArgs} args
+   * @returns {BookRecipe}
+   */
+  bookApproval(orderItemCriteriaList, defaultFlowStageParams, {
+    prerequisite,
+    brokerRole = null,
+    accessPass = null,
+    firstStageReqTemplateRef = null,
+    getFirstStageInput,
+  }) {
+    const p = new PFlowStage({
+      ...defaultFlowStageParams,
+      prerequisite,
+      templateRef: firstStageReqTemplateRef,
+      brokerRole,
+      accessPass,
+      getInput: getFirstStageInput,
+    });
+    const [simulateSellerApproval, orderFeedUpdateCollector] = OrderFeedUpdateFlowStageUtils.wrap({
+      wrappedStageFn: orderFeedUpdateListener => (new TestInterfaceActionFlowStage({
+        ...defaultFlowStageParams,
+        testName: 'Simulate Seller Approval (Test Interface Action)',
+        prerequisite: orderFeedUpdateListener,
+        createActionFn: () => ({
+          type: 'test:SellerAcceptOrderProposalSimulateAction',
+          objectType: 'OrderProposal',
+          objectId: p.getOutput().orderId,
+        }),
+      })),
+      orderFeedUpdateParams: {
+        ...defaultFlowStageParams,
+        prerequisite: p,
+        testName: 'Order Feed Update (after Simulate Seller Approval)',
+      },
+    });
+
+    const [b, orderFeedUpdateAfterDeleteProposal] = OrderFeedUpdateFlowStageUtils.wrap({
+      wrappedStageFn: orderFeedUpdateListener => (new BFlowStage({
+        ...defaultFlowStageParams,
+        prerequisite: orderFeedUpdateListener,
+        templateRef: 'afterP',
+        /* note that brokerRole & accessPass don't need to be passed. This is the minimal "B after P" call which
+        just presents `orderProposalVersion` and optional payment details */
+        getInput() {
+          const firstStageInput = getFirstStageInput();
+          return {
+            orderItems: firstStageInput.orderItems,
+            totalPaymentDue: p.getOutput().totalPaymentDue,
+            orderProposalVersion: p.getOutput().orderProposalVersion,
+            prepayment: p.getOutput().prepayment,
+          };
+        },
+      })),
+      orderFeedUpdateParams: {
+        ...defaultFlowStageParams,
+        prerequisite: orderFeedUpdateCollector,
+        testName: 'OrderProposal Deletion in Feed (after B)',
+      },
+    });
+
+    return new BookRecipe({
+      firstStage: p,
+      p,
+      simulateSellerApproval,
+      orderFeedUpdateCollector,
+      b,
+      orderFeedUpdateAfterDeleteProposal,
     });
   },
 };

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-utils.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-utils.js
@@ -139,6 +139,10 @@ const FlowStageUtils = {
    * @param {boolean} checks.doCheckIsValid If true, validation will be run
    * @param {UnknownFlowStageType | BookRecipe} flowStageOrBookRecipe If this is a BookRecipe,
    *   all stages within will be checked for validity/success.
+   *
+   *   NOTE It is recommended to only use a BookRecipe when expecting success. If expecting failure,
+   *   it is recommended to run only the first stage `describeRunAndRunChecks({ .. }, bookRecipe.firstStage)`.
+   *   There is no point simulating approval if P was expected to fail.
    * @param {() => void} [itAdditionalTests] Additional tests which will
    *   be run after success and validation tests have run.
    *   These tests need to create `it(..)` blocks for each of the new tests.
@@ -153,7 +157,12 @@ const FlowStageUtils = {
         approved items appearing in the feed - which means that the tests will time out */
         FlowStageUtils.describeRunAndRunChecks(checks, flowStageOrBookRecipe.simulateSellerApproval);
         FlowStageUtils.describeRunAndRunChecks(checks, flowStageOrBookRecipe.orderFeedUpdateCollector);
-        FlowStageUtils.describeRunAndRunChecks(checks, flowStageOrBookRecipe.b, itAdditionalTests);
+        FlowStageUtils.describeRunAndRunChecks(checks, flowStageOrBookRecipe.b);
+        FlowStageUtils.describeRunAndRunChecks(
+          checks,
+          flowStageOrBookRecipe.orderFeedUpdateAfterDeleteProposal,
+          itAdditionalTests,
+        );
       } else {
         FlowStageUtils.describeRunAndRunChecks(checks, flowStageOrBookRecipe.b, itAdditionalTests);
       }

--- a/packages/openactive-integration-tests/test/shared-behaviours/validation.js
+++ b/packages/openactive-integration-tests/test/shared-behaviours/validation.js
@@ -89,6 +89,10 @@ function shouldBeValidResponse(getter, name, logger, options, opportunityCriteri
     let { body } = response;
 
     if (['OrdersFeed', 'BookableRPDEFeed'].includes(options.validationMode)) {
+      // If this is an deleted RPDE item, there's nothing to validate.
+      if (body.state === 'deleted') {
+        return [];
+      }
       body = body.data;
     }
 


### PR DESCRIPTION
Add test to ensure that OrderProposal is always deleted after B, as per the spec.

This is also important to ensure that this change in the Orders Feed is collected explicitly before the next call is made, to avoid a race condition where the "delete" is actually picked up by any subsequent listeners.