### PR TITLE
feat: Better error for feed collection

### DIFF
--- a/packages/openactive-integration-tests/test/helpers/logger.js
+++ b/packages/openactive-integration-tests/test/helpers/logger.js
@@ -105,22 +105,24 @@ class BaseLogger {
   /**
    * @param {string} stage
    * @param {{[k: string]: unknown}} request
+   * @param {any} requestMetadata
    * @param {Promise<ChakramResponse>} responsePromise
    */
-  recordRequestResponse (stage, request, responsePromise) {
-    let entry = this.recordLogEntry({
-      type: "request",
-      stage: stage,
+  recordRequestResponse(stage, request, requestMetadata, responsePromise) {
+    const entry = this.recordLogEntry({
+      type: 'request',
+      stage,
       request: {
         ...request,
       },
       isPending: true,
+      requestMetadata,
       duration: 0,
     });
 
     // manually count how long it's been waiting
     // todo: capture a timestamp and hook into test state instead
-    let responseTimer = setInterval(() => {
+    const responseTimer = setInterval(() => {
       entry.duration += 100;
     }, 100);
 

--- a/packages/openactive-integration-tests/test/helpers/request-helper.js
+++ b/packages/openactive-integration-tests/test/helpers/request-helper.js
@@ -52,7 +52,7 @@ class RequestHelper {
    * @param {unknown | null} jsonBody Data to send - generally not applicable to
    *   GET requests. A JSON-serializable object.
    * @param {RequestOptions} requestOptions
-   * @param {any} requestMetadata
+   * @param {any} [requestMetadata]
    */
   async _request(stage, method, url, jsonBody, requestOptions, requestMetadata) {
     const params = { ...requestOptions };
@@ -85,7 +85,7 @@ class RequestHelper {
    * @param {string} stage
    * @param {string} url
    * @param {RequestOptions} requestOptions
-   * @param {any} requestMetadata
+   * @param {any} [requestMetadata]
    */
   async get(stage, url, requestOptions, requestMetadata) {
     return await this._request(stage, 'GET', url, null, requestOptions, requestMetadata);

--- a/packages/openactive-integration-tests/test/helpers/request-helper.js
+++ b/packages/openactive-integration-tests/test/helpers/request-helper.js
@@ -52,8 +52,9 @@ class RequestHelper {
    * @param {unknown | null} jsonBody Data to send - generally not applicable to
    *   GET requests. A JSON-serializable object.
    * @param {RequestOptions} requestOptions
+   * @param {any} requestMetadata
    */
-  async _request(stage, method, url, jsonBody, requestOptions) {
+  async _request(stage, method, url, jsonBody, requestOptions, requestMetadata) {
     const params = { ...requestOptions };
     if (jsonBody) {
       params.body = jsonBody;
@@ -66,7 +67,9 @@ class RequestHelper {
       url,
       jsonBody,
       requestOptions,
-    }, responsePromise);
+    },
+    requestMetadata,
+    responsePromise);
 
     if (jsonBody) {
       this.logger.recordRequest(stage, jsonBody);
@@ -82,9 +85,10 @@ class RequestHelper {
    * @param {string} stage
    * @param {string} url
    * @param {RequestOptions} requestOptions
+   * @param {any} requestMetadata
    */
-  async get(stage, url, requestOptions) {
-    return await this._request(stage, 'GET', url, null, requestOptions);
+  async get(stage, url, requestOptions, requestMetadata) {
+    return await this._request(stage, 'GET', url, null, requestOptions, requestMetadata);
   }
 
   /**
@@ -166,6 +170,12 @@ class RequestHelper {
       {
         timeout: BROKER_MICROSERVICE_FEED_REQUEST_TIMEOUT,
       },
+      {
+        feedExtract: {
+          id: eventId,
+          type: 'opportunities',
+        },
+      },
     );
 
     return respObj;
@@ -205,6 +215,12 @@ class RequestHelper {
       `${MICROSERVICE_BASE}/listeners/${type}/${encodeURIComponent(id)}`,
       {
         timeout: BROKER_MICROSERVICE_FEED_REQUEST_TIMEOUT,
+      },
+      {
+        feedExtract: {
+          id,
+          type,
+        },
       },
     );
 

--- a/packages/openactive-integration-tests/test/report-templates/report.md.handlebars
+++ b/packages/openactive-integration-tests/test/report-templates/report.md.handlebars
@@ -46,6 +46,13 @@ npm start -- --runInBand {{{ testFileName }}}
     {{/if}}
         {{#if isPending}}
 **Response still pending**
+        {{#if requestMetadata.feedExtract}}
+
+> This response is still pending because the Broker Microservice at `http://localhost:3000/` is still waiting for the `@id` `{{{ requestMetadata.feedExtract.id }}}` to appear in the {{{ requestMetadata.feedExtract.type }}} feed(s).
+> 
+> To troubleshoot this, try opening the last pages of the relevant {{{ requestMetadata.feedExtract.type }}} feed(s) (which will be empty) in Postman or similar, then refreshing that page after this test has run. Check that the `@id` exactly matches `{{{ requestMetadata.feedExtract.id }}}`. If the item does not appear at the end of the feed check that the `modified` timestamp of the RPDE item is being updated, and that the `next` url on each page in the feed is correctly referencing the appropriate feed.
+
+        {{/if}}
         {{/if}}
         {{#if response.status}}
 


### PR DESCRIPTION
Added the following message error for the case where a feed item cannot be found:

> This response is still pending because the Broker Microservice at `http://localhost:3000/` is still waiting for the `@id` `{{{ requestMetadata.feedExtract.id }}}` to appear in the {{{ requestMetadata.feedExtract.type }}} feed(s).
> 
> To troubleshoot this, try opening the last pages of the relevant {{{ requestMetadata.feedExtract.type }}} feed(s) (which will be empty) in Postman or similar, then refreshing that page after this test has run. Check that the `@id` exactly matches `{{{ requestMetadata.feedExtract.id }}}`. If the item does not appear at the end of the feed check that the `modified` timestamp of the RPDE item is being updated, and that the `next` url on each page in the feed is correctly referencing the appropriate feed.
