### PR TITLE
refactor: Move broker global state into one place

### DIFF
--- a/packages/openactive-broker-microservice/.eslintrc.json
+++ b/packages/openactive-broker-microservice/.eslintrc.json
@@ -33,7 +33,8 @@
           "**/*-test.js"
         ]
       }
-    ]
+    ],
+    "no-use-before-define": ["error", { "functions": false, "classes": false }]
   },
   "parserOptions": {
     "ecmaVersion": 2020

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-use-before-define */
 const express = require('express');
 const http = require('http');
 const logger = require('morgan');
@@ -1683,25 +1682,6 @@ setTimeout(() => {
     throw new Error(message);
   }
 }, 3600000); // 3600000 ms = 1 hour
-
-/**
- * Normalize a port into a number, string, or false.
- */
-function normalizePort(val) {
-  const integerPort = parseInt(val, 10);
-
-  if (Number.isNaN(integerPort)) {
-    // named pipe
-    return val;
-  }
-
-  if (integerPort >= 0) {
-    // port number
-    return integerPort;
-  }
-
-  return false;
-}
 
 /**
  * Event listener for HTTP server "error" event.

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -11,7 +11,7 @@ const path = require('path');
 const { performance } = require('perf_hooks');
 const { Base64 } = require('js-base64');
 const sleep = require('util').promisify(setTimeout);
-const { OpenActiveTestAuthKeyManager, setupBrowserAutomationRoutes, FatalError } = require('@openactive/openactive-openid-test-client');
+const { setupBrowserAutomationRoutes, FatalError } = require('@openactive/openactive-openid-test-client');
 const Handlebars = require('handlebars');
 const fs = require('fs').promises;
 const { Remarkable } = require('remarkable');
@@ -31,16 +31,19 @@ if (process.env.FORCE_TTY === 'true' && process.env.FORCE_TTY_COLUMNS) {
 // Inform config library that config is in the root directory (https://github.com/lorenwest/node-config/wiki/Configuration-Files#config-directory)
 process.env.NODE_CONFIG_DIR = path.join(__dirname, '..', '..', 'config');
 
+const config = require('config');
+const AsyncValidatorWorker = require('./src/validator/async-validator');
+const { silentlyAllowInsecureConnections } = require('./src/util/suppress-unauthorized-warning');
+const { OpportunityIdCache } = require('./src/util/opportunity-id-cache');
+const { logError, logErrorDuringHarvest, log, logCharacter } = require('./src/util/log');
+const { PORT, MICROSERVICE_BASE_URL } = require('./src/apiConfig');
+const { state, getTestDataset, getAllDatasets, addFeed } = require('./src/state');
+
 /**
  * @typedef {'orders' | 'order-proposals'} OrderFeedType
  * @typedef {'primary' | 'secondary'} BookingPartnerIdentifier
+ * @typedef {import('./src/models/FeedContext').FeedContext} FeedContext
  */
-
-const config = require('config');
-const AsyncValidatorWorker = require('./src/validator/async-validator');
-const PauseResume = require('./src/util/pause-resume');
-const { silentlyAllowInsecureConnections } = require('./src/util/suppress-unauthorized-warning');
-const { OpportunityIdCache } = require('./src/util/opportunity-id-cache');
 
 const markdown = new Remarkable();
 
@@ -75,8 +78,6 @@ const BUTTON_SELECTORS = config.has('broker.loginPagesSelectors') ? config.get('
 };
 const CONSOLE_OUTPUT_LEVEL = config.has('consoleOutputLevel') ? config.get('consoleOutputLevel') : 'detailed';
 
-const PORT = normalizePort(process.env.PORT || '3000');
-const MICROSERVICE_BASE_URL = `http://localhost:${PORT}`;
 const HEADLESS_AUTH = true;
 
 // Note this is duplicated between app.js and validator.js, for efficiency
@@ -89,38 +90,9 @@ const app = express();
 app.use(express.json());
 setupBrowserAutomationRoutes(app, BUTTON_SELECTORS);
 
-// eslint-disable-next-line no-console
-const logError = (x) => console.error(chalk.cyanBright(x));
-const logErrorDuringHarvest = (x) => console.error(chalk.cyanBright(`\n\n${x}\n\n\n\n\n\n\n\n\n`));
-// eslint-disable-next-line no-console
-const log = (x) => console.log(chalk.cyan(x));
-const logCharacter = (x) => process.stdout.write(chalk.cyan(x));
-
-const pauseResume = new PauseResume();
-
-const globalAuthKeyManager = new OpenActiveTestAuthKeyManager(log, MICROSERVICE_BASE_URL, config.get('sellers'), config.get('broker.bookingPartners'));
-
 if (REQUEST_LOGGING_ENABLED) {
   app.use(logger('dev'));
 }
-
-// nSQL joins appear to be slow, even with indexes. This is an optimisation pending further investigation
-const parentOpportunityMap = new Map();
-const parentOpportunityRpdeMap = new Map();
-const opportunityMap = new Map();
-const opportunityRpdeMap = new Map();
-const rowStoreMap = new Map();
-const parentIdIndex = new Map();
-
-const startTime = new Date();
-
-// create new progress bar container
-let multibar = null;
-
-let datasetSiteJson = {};
-
-const validatorThreadArray = [];
-const validationResults = new Map();
 
 /**
  * Use OpenActive validator to validate the opportunity
@@ -144,7 +116,7 @@ async function validateAndStoreValidationResults(data, validator) {
     }
 
     // Create a new entry if this is a new error
-    let currentValidationResults = validationResults.get(errorKey);
+    let currentValidationResults = state.validationResults.get(errorKey);
     if (!currentValidationResults) {
       currentValidationResults = {
         path: error.path,
@@ -152,7 +124,7 @@ async function validateAndStoreValidationResults(data, validator) {
         occurrences: 0,
         examples: [],
       };
-      validationResults.set(errorKey, currentValidationResults);
+      state.validationResults.set(errorKey, currentValidationResults);
     }
 
     // Keep track of examples of each error, with a preference for newer ones (later in the feed)
@@ -169,7 +141,7 @@ async function validateAndStoreValidationResults(data, validator) {
  */
 async function renderValidationErrorsHtml() {
   return renderTemplate('validation-errors', {
-    validationErrors: [...validationResults.entries()].map(([errorKey, obj]) => ({
+    validationErrors: [...state.validationResults.entries()].map(([errorKey, obj]) => ({
       errorKey,
       ...obj,
     })),
@@ -182,7 +154,7 @@ async function renderValidationErrorsHtml() {
  * @param {string} id The `@id` of the JSON-LD object
  */
 function renderOpenValidatorHref(id) {
-  const cachedResponse = opportunityMap.get(id) || parentOpportunityMap.get(id);
+  const cachedResponse = state.opportunityMap.get(id) || state.parentOpportunityMap.get(id);
   if (cachedResponse) {
     const jsonString = JSON.stringify(cachedResponse, null, 2);
     return `https://validator.openactive.io/?validationMode=${ITEM_VALIDATION_MODE}#/json/${Base64.encodeURI(jsonString)}`;
@@ -212,42 +184,6 @@ async function renderTemplate(templateName, data) {
       renderMarkdown: (text) => markdown.render(text),
     },
   });
-}
-
-let opportunityIdCache = OpportunityIdCache.create();
-
-/**
- * @typedef FeedContext
- * @property {string} currentPage
- * @property {number} pages
- * @property {number} items
- * @property {number[]} responseTimes
- * @property {number} totalItemsQueuedForValidation
- * @property {number} validatedItems
- * @property {boolean} [sleepMode]
- * @property {string} [timeToHarvestCompletion]
- */
-/**
- * Harvesting state for each RPDE feed.
- *
- * Key = Either:
- *   - 'OrdersFeed' - it's the Orders Feed
- *   - 'OrderProposalsFeed' - it's the OrderProposalsFeed
- *   - 'ScheduledSession'|'SessionSeries'|'FacilityUseSlot'|..etc - It's one of the Oportunity feeds.
- * @type {Map<string, FeedContext>}
- */
-const feedContextMap = new Map();
-
-const testDatasets = new Map();
-function getTestDataset(testDatasetIdentifier) {
-  if (!testDatasets.has(testDatasetIdentifier)) {
-    testDatasets.set(testDatasetIdentifier, new Set());
-  }
-  return testDatasets.get(testDatasetIdentifier);
-}
-
-function getAllDatasets() {
-  return new Set(Array.from(testDatasets.values()).flatMap((x) => Array.from(x.values())));
 }
 
 /**
@@ -287,8 +223,8 @@ function withOrdersRpdeHeaders(getHeadersFn) {
 async function harvestRPDE(baseUrl, feedIdentifier, headers, processPage, isOrdersFeed, bar, totalItems, waitForValidation) {
   // Limit validator to 5 minutes if WAIT_FOR_HARVEST is set
   const validatorTimeout = WAIT_FOR_HARVEST ? 1000 * 60 * 5 : null;
-  const validator = new AsyncValidatorWorker(feedIdentifier, waitForValidation, startTime, validatorTimeout);
-  validatorThreadArray.push(validator);
+  const validator = new AsyncValidatorWorker(feedIdentifier, waitForValidation, state.startTime, validatorTimeout);
+  state.validatorThreadArray.push(validator);
 
   let isInitialHarvestComplete = false;
   let numberOfRetries = 0;
@@ -319,10 +255,10 @@ async function harvestRPDE(baseUrl, feedIdentifier, headers, processPage, isOrde
     ...progressFromContext(context),
   });
 
-  if (feedContextMap.has(feedIdentifier)) {
+  if (state.feedContextMap.has(feedIdentifier)) {
     throw new Error('Duplicate feed identifier not permitted within dataset distribution.');
   }
-  feedContextMap.set(feedIdentifier, context);
+  state.feedContextMap.set(feedIdentifier, context);
   let url = baseUrl;
 
   // One instance of FeedPageChecker per feed, as it maintains state relating to the feed
@@ -331,7 +267,7 @@ async function harvestRPDE(baseUrl, feedIdentifier, headers, processPage, isOrde
   // Harvest forever, until a 404 is encountered
   for (;;) {
     // If harvesting is paused, block using the mutex
-    await pauseResume.waitIfPaused();
+    await state.pauseResume.waitIfPaused();
 
     try {
       const options = {
@@ -345,7 +281,7 @@ async function harvestRPDE(baseUrl, feedIdentifier, headers, processPage, isOrde
 
       const json = response.data;
 
-      // Validate RPDE page using RPDE Validator, noting that for non-2xx responses that we want to retry axios will have already thrown an error above
+      // Validate RPDE page using RPDE Validator, noting that for non-2xx state.pendingGetOpportunityResponses that we want to retry axios will have already thrown an error above
       const rpdeValidationErrors = feedChecker.validateRpdePage({
         url,
         json,
@@ -357,7 +293,7 @@ async function harvestRPDE(baseUrl, feedIdentifier, headers, processPage, isOrde
       });
 
       if (rpdeValidationErrors.length > 0) {
-        if (multibar) multibar.stop();
+        if (state.multibar) state.multibar.stop();
         logError(`\nFATAL ERROR: RPDE Validation Error(s) found on RPDE feed ${feedIdentifier} page "${url}":\n${rpdeValidationErrors.map((error) => `- ${error.message.split('\n')[0]}`).join('\n')}\n`);
         process.exit(1);
       }
@@ -380,9 +316,9 @@ async function harvestRPDE(baseUrl, feedIdentifier, headers, processPage, isOrde
           await setFeedIsUpToDate(feedIdentifier);
         } else if (VERBOSE) log(`Sleep mode poll for RPDE feed "${url}"`);
         context.sleepMode = true;
-        if (context.timeToHarvestCompletion === undefined) context.timeToHarvestCompletion = millisToMinutesAndSeconds((new Date()).getTime() - startTime.getTime());
+        if (context.timeToHarvestCompletion === undefined) context.timeToHarvestCompletion = millisToMinutesAndSeconds((new Date()).getTime() - state.startTime.getTime());
         // Slow down sleep polling while waiting for harvesting of other feeds to complete
-        await sleep(WAIT_FOR_HARVEST && incompleteFeeds.length !== 0 ? 5000 : 500);
+        await sleep(WAIT_FOR_HARVEST && state.incompleteFeeds.length !== 0 ? 5000 : 500);
       } else {
         context.responseTimes.push(responseTime);
         // Maintain a buffer of the last 5 items
@@ -437,18 +373,18 @@ async function harvestRPDE(baseUrl, feedIdentifier, headers, processPage, isOrde
       }
       if (error instanceof FatalError) {
         // If a fatal error, quit the application immediately
-        if (multibar) multibar.stop();
+        if (state.multibar) state.multibar.stop();
         logError(`\nFATAL ERROR for RPDE feed ${feedIdentifier} page "${url}": ${error.message}\n`);
         process.exit(1);
       } else if (!error.isAxiosError) {
         // If a non-axios error, quit the application immediately
-        if (multibar) multibar.stop();
+        if (state.multibar) state.multibar.stop();
         logErrorDuringHarvest(`FATAL ERROR for RPDE feed ${feedIdentifier} page "${url}": ${error.message}\n${error.stack}`);
         process.exit(1);
       } else if (error.response?.status === 404) {
         // If 404, simply stop polling feed
         if (WAIT_FOR_HARVEST || VALIDATE_ONLY) await setFeedIsUpToDate(feedIdentifier);
-        multibar.remove(progressbar);
+        state.multibar.remove(progressbar);
         if (feedIdentifier !== ORDER_PROPOSALS_FEED_IDENTIFIER) logErrorDuringHarvest(`Not Found error for RPDE feed ${feedIdentifier} page "${url}", feed will be ignored.`);
         return;
       } else {
@@ -458,7 +394,7 @@ async function harvestRPDE(baseUrl, feedIdentifier, headers, processPage, isOrde
           numberOfRetries += 1;
           await sleep(5000);
         } else {
-          if (multibar) multibar.stop();
+          if (state.multibar) state.multibar.stop();
           logError(`\nFATAL ERROR: Retry limit exceeded for RPDE feed ${feedIdentifier} page "${url}"\n`);
           process.exit(1);
         }
@@ -477,7 +413,7 @@ async function harvestRPDE(baseUrl, feedIdentifier, headers, processPage, isOrde
  * @returns {any}
  */
 function getRandomBookableOpportunity({ sellerId, bookingFlow, opportunityType, criteriaName, testDatasetIdentifier }) {
-  const typeBucket = OpportunityIdCache.getTypeBucket(opportunityIdCache, {
+  const typeBucket = OpportunityIdCache.getTypeBucket(state.opportunityIdCache, {
     criteriaName, bookingFlow, opportunityType,
   });
   const sellerCompartment = typeBucket.contents.get(sellerId);
@@ -524,7 +460,7 @@ function getRandomBookableOpportunity({ sellerId, bookingFlow, opportunityType, 
  * @param {string} args.bookingFlow
  */
 function assertOpportunityCriteriaNotFound({ opportunityType, criteriaName, bookingFlow }) {
-  const typeBucket = OpportunityIdCache.getTypeBucket(opportunityIdCache, {
+  const typeBucket = OpportunityIdCache.getTypeBucket(state.opportunityIdCache, {
     criteriaName, opportunityType, bookingFlow,
   });
 
@@ -539,15 +475,15 @@ function releaseOpportunityLocks(testDatasetIdentifier) {
 }
 
 function getOpportunityById(opportunityId) {
-  const opportunity = opportunityMap.get(opportunityId);
+  const opportunity = state.opportunityMap.get(opportunityId);
   if (!opportunity) {
     return null;
   }
   if (!jsonLdHasReferencedParent(opportunity)) {
     return opportunity;
   }
-  const superEvent = parentOpportunityMap.get(opportunity.superEvent);
-  const facilityUse = parentOpportunityMap.get(opportunity.facilityUse);
+  const superEvent = state.parentOpportunityMap.get(opportunity.superEvent);
+  const facilityUse = state.parentOpportunityMap.get(opportunity.facilityUse);
   if (superEvent || facilityUse) {
     const mergedContexts = getMergedJsonLdContext(opportunity, superEvent, facilityUse);
     delete opportunity['@context'];
@@ -580,46 +516,22 @@ function getOpportunityById(opportunityId) {
 }
 
 /**
- * @typedef {object} PendingResponse
- * @property {(json: any) => void} send
- * @property {() => void} cancel
- */
-
-/** @type {{[id: string]: PendingResponse}} */
-const responses = {};
-
-const healthCheckResponsesWaitingForHarvest = [];
-/**
- * List of Feed identifiers which have not yet completed harvesting.
- *
- * @type {string[]}
- */
-const incompleteFeeds = [];
-
-/**
- * @param {string} feedIdentifier
- */
-function addFeed(feedIdentifier) {
-  incompleteFeeds.push(feedIdentifier);
-}
-
-/**
  * @param {string} feedIdentifier
  */
 async function setFeedIsUpToDate(feedIdentifier) {
-  if (incompleteFeeds.length !== 0) {
-    const index = incompleteFeeds.indexOf(feedIdentifier);
+  if (state.incompleteFeeds.length !== 0) {
+    const index = state.incompleteFeeds.indexOf(feedIdentifier);
     if (index > -1) {
       // Remove the feed from the list
-      incompleteFeeds.splice(index, 1);
+      state.incompleteFeeds.splice(index, 1);
 
-      // If the list is now empty, trigger responses to healthcheck
-      if (incompleteFeeds.length === 0) {
+      // If the list is now empty, trigger state.pendingGetOpportunityResponses to healthcheck
+      if (state.incompleteFeeds.length === 0) {
         // Stop the validator threads as soon as we've finished harvesting - so only a subset of the results will be validated
         // Note in some circumstances threads will complete their work before terminating
-        await Promise.all(validatorThreadArray.map(async (validator) => validator.terminate));
+        await Promise.all(state.validatorThreadArray.map(async (validator) => validator.terminate));
 
-        if (multibar) multibar.stop();
+        if (state.multibar) state.multibar.stop();
 
         log('Harvesting is up-to-date');
         const { childOrphans, totalChildren, percentageChildOrphans, totalOpportunities } = getOrphanStats();
@@ -652,10 +564,10 @@ async function setFeedIsUpToDate(feedIdentifier) {
           validationPassed = false;
         }
 
-        if (validationResults.size > 0) {
+        if (state.validationResults.size > 0) {
           await fs.writeFile(`${OUTPUT_PATH}validation-errors.html`, await renderValidationErrorsHtml());
-          const occurrenceCount = [...validationResults.values()].reduce((total, result) => total + result.occurrences, 0);
-          logError(`\nFATAL ERROR: Validation errors were found in the opportunity data feeds. ${occurrenceCount} errors were reported of which ${validationResults.size} were unique.`);
+          const occurrenceCount = [...state.validationResults.values()].reduce((total, result) => total + result.occurrences, 0);
+          logError(`\nFATAL ERROR: Validation errors were found in the opportunity data feeds. ${occurrenceCount} errors were reported of which ${state.validationResults.size} were unique.`);
           if (!VALIDATE_ONLY && !IS_RUNNING_IN_CI) {
             logError(`Open ${OUTPUT_PATH}validation-errors.html or http://localhost:${PORT}/validation-errors in your browser for more information\n`);
           } else {
@@ -675,7 +587,7 @@ async function setFeedIsUpToDate(feedIdentifier) {
             log(chalk.red('(press ctrl+c to close or wait 60 seconds)\n'));
             // Pause harvester and sleep for 1 minute to allow the user to access the /orphans page, before throwing the fatal error
             // User interaction is not required to exit, for compatibility with CI
-            await pauseResume.pause();
+            await state.pauseResume.pause();
             await sleep(60000);
           }
           process.exit(1);
@@ -688,11 +600,11 @@ async function setFeedIsUpToDate(feedIdentifier) {
 }
 
 function unlockHealthCheck() {
-  healthCheckResponsesWaitingForHarvest.forEach((res) => res.send('openactive-broker'));
+  state.healthCheckResponsesWaitingForHarvest.forEach((res) => res.send('openactive-broker'));
   // Clear response array
-  healthCheckResponsesWaitingForHarvest.splice(0, healthCheckResponsesWaitingForHarvest.length);
-  // Clear incompleteFeeds array
-  incompleteFeeds.splice(0, incompleteFeeds.length);
+  state.healthCheckResponsesWaitingForHarvest.splice(0, state.healthCheckResponsesWaitingForHarvest.length);
+  // Clear state.incompleteFeeds array
+  state.incompleteFeeds.splice(0, state.incompleteFeeds.length);
 }
 
 // Provide helpful homepage as binding for root to allow the service to run in a container
@@ -717,18 +629,18 @@ app.get('/health-check', async function (req, res) {
   // Healthcheck response will block until all feeds are up-to-date, which is useful in CI environments
   // to ensure that the tests will not run until the feeds have been fully consumed
   // Allow blocking for up to 10 minutes to fully harvest the feed
-  const wasPaused = pauseResume.resume();
+  const wasPaused = state.pauseResume.resume();
   if (wasPaused) log('Harvesting resumed');
   req.setTimeout(1000 * 60 * 10);
-  if (WAIT_FOR_HARVEST && incompleteFeeds.length !== 0) {
-    healthCheckResponsesWaitingForHarvest.push(res);
+  if (WAIT_FOR_HARVEST && state.incompleteFeeds.length !== 0) {
+    state.healthCheckResponsesWaitingForHarvest.push(res);
   } else {
     res.send('openactive-broker');
   }
 });
 
 app.post('/pause', async function (req, res) {
-  await pauseResume.pause();
+  await state.pauseResume.pause();
   log('Harvesting paused');
   res.send();
 });
@@ -738,17 +650,20 @@ function getConfig() {
     // Allow a consistent startDate to be used when calling test-interface-criteria
     harvestStartTime: HARVEST_START_TIME,
     // Base URL used by the integration tests
-    bookingApiBaseUrl: datasetSiteJson.accessService?.endpointURL,
+    bookingApiBaseUrl: state.datasetSiteJson.accessService?.endpointURL,
     // Base URL used by the authentication tests
-    authenticationAuthority: datasetSiteJson.accessService?.authenticationAuthority,
-    ...globalAuthKeyManager.config,
+    authenticationAuthority: state.datasetSiteJson.accessService?.authenticationAuthority,
+    ...state.globalAuthKeyManager.config,
     headlessAuth: HEADLESS_AUTH,
   };
 }
 
+/**
+ * @param {string} bookingPartnerIdentifier
+ */
 function getOrdersFeedHeader(bookingPartnerIdentifier) {
   return async () => {
-    await globalAuthKeyManager.refreshClientCredentialsAccessTokensIfNeeded();
+    await state.globalAuthKeyManager.refreshClientCredentialsAccessTokensIfNeeded();
     const accessToken = getConfig()?.bookingPartnersConfig?.[bookingPartnerIdentifier]?.authentication?.orderFeedTokenSet?.access_token;
     const requestHeaders = getConfig()?.bookingPartnersConfig?.[bookingPartnerIdentifier]?.authentication?.ordersFeedRequestHeaders;
     return {
@@ -762,12 +677,12 @@ function getOrdersFeedHeader(bookingPartnerIdentifier) {
 
 // Config endpoint used to get global variables within the integration tests
 app.get('/config', async function (req, res) {
-  await globalAuthKeyManager.refreshAuthorizationCodeFlowAccessTokensIfNeeded();
+  await state.globalAuthKeyManager.refreshAuthorizationCodeFlowAccessTokensIfNeeded();
   res.json(getConfig());
 });
 
 app.get('/dataset-site', function (req, res) {
-  res.json(datasetSiteJson);
+  res.json(state.datasetSiteJson);
 });
 
 /**
@@ -818,7 +733,7 @@ function millisToMinutesAndSeconds(millis) {
 }
 
 function getOrphanJson() {
-  const rows = Array.from(rowStoreMap.values()).filter((x) => x.jsonLdParentId !== null);
+  const rows = Array.from(state.rowStoreMap.values()).filter((x) => x.jsonLdParentId !== null);
   return {
     children: {
       matched: rows.filter((x) => !x.waitingForParentToBeIngested).length,
@@ -852,10 +767,10 @@ app.get('/orphans', function (req, res) {
  * @returns {OrphanStats}
  */
 function getOrphanStats() {
-  const childRows = Array.from(rowStoreMap.values()).filter((x) => x.jsonLdParentId !== null);
+  const childRows = Array.from(state.rowStoreMap.values()).filter((x) => x.jsonLdParentId !== null);
   const childOrphans = childRows.filter((x) => x.waitingForParentToBeIngested).length;
   const totalChildren = childRows.length;
-  const totalOpportunities = Array.from(rowStoreMap.values()).filter((x) => !x.waitingForParentToBeIngested).length;
+  const totalOpportunities = Array.from(state.rowStoreMap.values()).filter((x) => !x.waitingForParentToBeIngested).length;
   const percentageChildOrphans = totalChildren > 0 ? ((childOrphans / totalChildren) * 100).toFixed(2) : '0';
   return {
     childOrphans,
@@ -868,14 +783,14 @@ function getOrphanStats() {
 app.get('/status', function (req, res) {
   const { childOrphans, totalChildren, percentageChildOrphans, totalOpportunities } = getOrphanStats();
   res.send({
-    elapsedTime: millisToMinutesAndSeconds((new Date()).getTime() - startTime.getTime()),
-    harvestingStatus: pauseResume.pauseHarvestingStatus,
-    feeds: mapToObjectSummary(feedContextMap),
+    elapsedTime: millisToMinutesAndSeconds((new Date()).getTime() - state.startTime.getTime()),
+    harvestingStatus: state.pauseResume.pauseHarvestingStatus,
+    feeds: mapToObjectSummary(state.feedContextMap),
     orphans: {
       children: `${childOrphans} of ${totalChildren} (${percentageChildOrphans}%)`,
     },
     totalOpportunitiesHarvested: totalOpportunities,
-    buckets: DO_NOT_FILL_BUCKETS ? null : mapToObjectSummary(opportunityIdCache),
+    buckets: DO_NOT_FILL_BUCKETS ? null : mapToObjectSummary(state.opportunityIdCache),
   });
 });
 
@@ -884,14 +799,14 @@ app.get('/validation-errors', async function (req, res) {
 });
 
 app.delete('/opportunity-cache', function (req, res) {
-  parentOpportunityMap.clear();
-  parentOpportunityRpdeMap.clear();
-  opportunityMap.clear();
-  opportunityRpdeMap.clear();
-  rowStoreMap.clear();
-  parentIdIndex.clear();
+  state.parentOpportunityMap.clear();
+  state.parentOpportunityRpdeMap.clear();
+  state.opportunityMap.clear();
+  state.opportunityRpdeMap.clear();
+  state.rowStoreMap.clear();
+  state.parentIdIndex.clear();
 
-  opportunityIdCache = OpportunityIdCache.create();
+  state.opportunityIdCache = OpportunityIdCache.create();
 
   res.status(204).send();
 });
@@ -924,16 +839,6 @@ app.get('/opportunity-cache/:id', function (req, res) {
 });
 
 /**
- * @typedef {{
- *   item: any,
- *   collectRes: import('express').Response | null,
- * }} Listener
- *
- * @type {Map<string, Listener>}
- */
-const listeners = new Map();
-
-/**
  * @param {string} type
  * @param {string} id
  */
@@ -959,15 +864,15 @@ function handleListeners(type, id, item) {
   // If there is a listener for this ID, the listener map needs to be populated with either the item or
   // the collection request must be fulfilled
   const { listenerId } = getListenerInfo(type, id);
-  if (listeners.get(listenerId)) {
-    const { collectRes } = listeners.get(listenerId);
+  if (state.orderUuidListeners.get(listenerId)) {
+    const { collectRes } = state.orderUuidListeners.get(listenerId);
     // If there's already a collection request, fulfill it
     if (collectRes) {
       collectRes.json(item);
-      listeners.delete(listenerId);
+      state.orderUuidListeners.delete(listenerId);
     } else {
       // If not, set the opportunity so that it can returned when the collection call arrives
-      listeners.set(listenerId, {
+      state.orderUuidListeners.set(listenerId, {
         item, collectRes: null,
       });
     }
@@ -988,16 +893,16 @@ app.post('/listeners/:type/:id', async function (req, res) {
       error: 'Order feed items are not available as \'disableOrdersFeedHarvesting\' is set to \'true\' in the test suite configuration.',
     });
   }
-  if (listeners.has(listenerId)) {
+  if (state.orderUuidListeners.has(listenerId)) {
     return res.status(409).send({
       error: `The ${idName} "${id}" already has a listener registered. The same ${idName} must not be used across multiple tests, or listened for multiple times concurrently within the same test.`,
     });
   }
-  listeners.set(listenerId, {
+  state.orderUuidListeners.set(listenerId, {
     item: null, collectRes: null,
   });
   if (isForOrdersFeed) {
-    const feedContext = feedContextMap.get(orderFeedIdentifier(type === 'orders' ? ORDERS_FEED_IDENTIFIER : ORDER_PROPOSALS_FEED_IDENTIFIER, bookingPartnerIdentifier));
+    const feedContext = state.feedContextMap.get(orderFeedIdentifier(type === 'orders' ? ORDERS_FEED_IDENTIFIER : ORDER_PROPOSALS_FEED_IDENTIFIER, bookingPartnerIdentifier));
     return res.status(200).send({
       headers: await withOrdersRpdeHeaders(getOrdersFeedHeader('primary'))(),
       startingFeedPage: feedContext?.currentPage,
@@ -1014,15 +919,15 @@ app.get('/listeners/:type/:id', function (req, res) {
     res.status(400).json({
       error: 'id is required',
     });
-  } else if (listeners.get(listenerId)) {
-    const { item } = listeners.get(listenerId);
+  } else if (state.orderUuidListeners.get(listenerId)) {
+    const { item } = state.orderUuidListeners.get(listenerId);
     if (!item) {
-      listeners.set(listenerId, {
+      state.orderUuidListeners.set(listenerId, {
         item: null, collectRes: res,
       });
     } else {
       res.json(item);
-      listeners.delete(listenerId);
+      state.orderUuidListeners.delete(listenerId);
     }
   } else {
     res.status(404).json({
@@ -1057,10 +962,10 @@ app.get('/opportunity/:id', function (req, res) {
       }
 
       // Stash the response and reply later when an event comes through (kill any existing id still waiting)
-      if (responses[id] && responses[id] !== null) responses[id].cancel();
-      responses[id] = {
+      if (state.pendingGetOpportunityResponses[id] && state.pendingGetOpportunityResponses[id] !== null) state.pendingGetOpportunityResponses[id].cancel();
+      state.pendingGetOpportunityResponses[id] = {
         send(json) {
-          responses[id] = null;
+          state.pendingGetOpportunityResponses[id] = null;
           res.json(json);
         },
         cancel() {
@@ -1265,16 +1170,16 @@ async function ingestParentOpportunityPage(rpdePage, feedIdentifier, validateIte
   for (const item of rpdePage.items) {
     const feedItemIdentifier = feedPrefix + item.id;
     if (item.state === 'deleted') {
-      const jsonLdId = parentOpportunityRpdeMap.get(feedItemIdentifier);
-      parentOpportunityMap.delete(jsonLdId);
-      parentOpportunityRpdeMap.delete(feedItemIdentifier);
+      const jsonLdId = state.parentOpportunityRpdeMap.get(feedItemIdentifier);
+      state.parentOpportunityMap.delete(jsonLdId);
+      state.parentOpportunityRpdeMap.delete(feedItemIdentifier);
     } else {
       // Run any validation logic for this item
       await validateItemFn(item.data);
 
       const jsonLdId = item.data['@id'] || item.data.id;
-      parentOpportunityRpdeMap.set(feedItemIdentifier, jsonLdId);
-      parentOpportunityMap.set(jsonLdId, item.data);
+      state.parentOpportunityRpdeMap.set(feedItemIdentifier, jsonLdId);
+      state.parentOpportunityMap.set(jsonLdId, item.data);
     }
   }
 
@@ -1290,9 +1195,9 @@ async function ingestOpportunityPage(rpdePage, feedIdentifier, validateItemFn) {
   for (const item of rpdePage.items) {
     const feedItemIdentifier = feedPrefix + item.id;
     if (item.state === 'deleted') {
-      const jsonLdId = opportunityRpdeMap.get(feedItemIdentifier);
-      opportunityMap.delete(jsonLdId);
-      opportunityRpdeMap.delete(feedItemIdentifier);
+      const jsonLdId = state.opportunityRpdeMap.get(feedItemIdentifier);
+      state.opportunityMap.delete(jsonLdId);
+      state.opportunityRpdeMap.delete(feedItemIdentifier);
 
       deleteOpportunityItem(jsonLdId);
     } else {
@@ -1300,8 +1205,8 @@ async function ingestOpportunityPage(rpdePage, feedIdentifier, validateItemFn) {
       await validateItemFn(item.data);
 
       const jsonLdId = item.data['@id'] || item.data.id;
-      opportunityRpdeMap.set(feedItemIdentifier, jsonLdId);
-      opportunityMap.set(jsonLdId, item.data);
+      state.opportunityRpdeMap.set(feedItemIdentifier, jsonLdId);
+      state.opportunityMap.set(jsonLdId, item.data);
 
       await storeOpportunityItem(item);
     }
@@ -1312,16 +1217,16 @@ async function touchOpportunityItems(parentIds) {
   const opportunitiesToUpdate = new Set();
 
   parentIds.forEach((parentId) => {
-    if (parentIdIndex.has(parentId)) {
-      parentIdIndex.get(parentId).forEach((jsonLdId) => {
+    if (state.parentIdIndex.has(parentId)) {
+      state.parentIdIndex.get(parentId).forEach((jsonLdId) => {
         opportunitiesToUpdate.add(jsonLdId);
       });
     }
   });
 
   await Promise.all([...opportunitiesToUpdate].map(async (jsonLdId) => {
-    if (rowStoreMap.has(jsonLdId)) {
-      const row = rowStoreMap.get(jsonLdId);
+    if (state.rowStoreMap.has(jsonLdId)) {
+      const row = state.rowStoreMap.get(jsonLdId);
       row.feedModified = Date.now() + 1000; // 1 second in the future
       row.waitingForParentToBeIngested = false;
       await processRow(row);
@@ -1330,13 +1235,13 @@ async function touchOpportunityItems(parentIds) {
 }
 
 function deleteOpportunityItem(jsonLdId) {
-  const row = rowStoreMap.get(jsonLdId);
+  const row = state.rowStoreMap.get(jsonLdId);
   if (row) {
-    const idx = parentIdIndex.get(row.jsonLdParentId);
+    const idx = state.parentIdIndex.get(row.jsonLdParentId);
     if (idx) {
       idx.delete(jsonLdId);
     }
-    rowStoreMap.delete(jsonLdId);
+    state.rowStoreMap.delete(jsonLdId);
   }
 }
 
@@ -1352,16 +1257,16 @@ async function storeOpportunityItem(item) {
     jsonLd: item.data,
     jsonLdType: item.data['@type'] || item.data.type,
     jsonLdParentId: !jsonLdHasReferencedParent(item.data) ? null : item.data.superEvent || item.data.facilityUse,
-    waitingForParentToBeIngested: jsonLdHasReferencedParent(item.data) && !(parentOpportunityMap.has(item.data.superEvent) || parentOpportunityMap.has(item.data.facilityUse)),
+    waitingForParentToBeIngested: jsonLdHasReferencedParent(item.data) && !(state.parentOpportunityMap.has(item.data.superEvent) || state.parentOpportunityMap.has(item.data.facilityUse)),
   };
 
   if (row.jsonLdId != null) {
     if (row.jsonLdParentId != null) {
-      if (!parentIdIndex.has(row.jsonLdParentId)) parentIdIndex.set(row.jsonLdParentId, new Set());
-      parentIdIndex.get(row.jsonLdParentId).add(row.jsonLdId);
+      if (!state.parentIdIndex.has(row.jsonLdParentId)) state.parentIdIndex.set(row.jsonLdParentId, new Set());
+      state.parentIdIndex.get(row.jsonLdParentId).add(row.jsonLdId);
     }
 
-    rowStoreMap.set(row.jsonLdId, row);
+    state.rowStoreMap.set(row.jsonLdId, row);
 
     if (!row.waitingForParentToBeIngested) {
       await processRow(row);
@@ -1398,7 +1303,7 @@ async function processRow(row) {
       data: row.jsonLd,
     };
   } else {
-    const parentOpportunity = parentOpportunityMap.get(row.jsonLdParentId);
+    const parentOpportunity = state.parentOpportunityMap.get(row.jsonLdParentId);
     const mergedContexts = getMergedJsonLdContext(row.jsonLd, parentOpportunity);
 
     const parentOpportunityWithoutContext = {
@@ -1463,7 +1368,7 @@ async function processOpportunityItem(item) {
         }),
       }))) {
         for (const bookingFlow of bookingFlows) {
-          const typeBucket = OpportunityIdCache.getTypeBucket(opportunityIdCache, {
+          const typeBucket = OpportunityIdCache.getTypeBucket(state.opportunityIdCache, {
             criteriaName, opportunityType, bookingFlow,
           });
           if (!typeBucket.contents.has(sellerId)) typeBucket.contents.set(sellerId, new Set());
@@ -1488,14 +1393,14 @@ async function processOpportunityItem(item) {
       }
     }
 
-    if (responses[id]) {
-      responses[id].send(item);
+    if (state.pendingGetOpportunityResponses[id]) {
+      state.pendingGetOpportunityResponses[id].send(item);
     }
 
     if (VERBOSE) {
       const bookableIssueList = unmetCriteriaDetails.length > 0
         ? `\n   [Unmet Criteria: ${Array.from(new Set(unmetCriteriaDetails)).join(', ')}]` : '';
-      if (responses[id]) {
+      if (state.pendingGetOpportunityResponses[id]) {
         log(`seen ${matchingCriteria.join(', ')} and dispatched ${id}${bookableIssueList}`);
       } else {
         log(`saw ${matchingCriteria.join(', ')} ${id}${bookableIssueList}`);
@@ -1618,12 +1523,12 @@ Validation errors found in Dataset Site JSON-LD:
   }
 
   // Set global based on data result
-  datasetSiteJson = dataset;
+  state.datasetSiteJson = dataset;
 
   if (!VALIDATE_ONLY) {
     if (dataset.accessService?.authenticationAuthority) {
       try {
-        await globalAuthKeyManager.initialise(dataset.accessService.authenticationAuthority, HEADLESS_AUTH);
+        await state.globalAuthKeyManager.initialise(dataset.accessService.authenticationAuthority, HEADLESS_AUTH);
       } catch (error) {
         if (error instanceof FatalError) {
           // If a fatal error, just rethrow
@@ -1672,7 +1577,7 @@ Validation errors found in Dataset Site JSON-LD:
   };
 
   const hasTotalItems = dataset.distribution.filter((x) => x.totalItems).length > 0;
-  multibar = new cliProgress.MultiBar({
+  state.multibar = new cliProgress.MultiBar({
     clearOnComplete: false,
     hideCursor: false,
     noTTYOutput: true,
@@ -1688,11 +1593,11 @@ Validation errors found in Dataset Site JSON-LD:
     if (isParentFeed[dataDownload.additionalType] === true) {
       log(`Found parent opportunity feed: ${dataDownload.contentUrl}`);
       addFeed(feedIdentifier);
-      harvesters.push(harvestRPDE(dataDownload.contentUrl, feedIdentifier, withOpportunityRpdeHeaders(async () => OPPORTUNITY_FEED_REQUEST_HEADERS), ingestParentOpportunityPage, false, multibar, dataDownload.totalItems, true));
+      harvesters.push(harvestRPDE(dataDownload.contentUrl, feedIdentifier, withOpportunityRpdeHeaders(async () => OPPORTUNITY_FEED_REQUEST_HEADERS), ingestParentOpportunityPage, false, state.multibar, dataDownload.totalItems, true));
     } else if (isParentFeed[dataDownload.additionalType] === false) {
       log(`Found opportunity feed: ${dataDownload.contentUrl}`);
       addFeed(feedIdentifier);
-      harvesters.push(harvestRPDE(dataDownload.contentUrl, feedIdentifier, withOpportunityRpdeHeaders(async () => OPPORTUNITY_FEED_REQUEST_HEADERS), ingestOpportunityPage, false, multibar, dataDownload.totalItems, false));
+      harvesters.push(harvestRPDE(dataDownload.contentUrl, feedIdentifier, withOpportunityRpdeHeaders(async () => OPPORTUNITY_FEED_REQUEST_HEADERS), ingestOpportunityPage, false, state.multibar, dataDownload.totalItems, false));
     } else {
       logError(`\nERROR: Found unsupported feed in dataset site "${dataDownload.contentUrl}" with additionalType "${dataDownload.additionalType}"`);
       logError(`Only the following additionalType values are supported: \n${Object.keys(isParentFeed).map((x) => `- "${x}"`).join('\n')}'`);
@@ -1728,7 +1633,7 @@ Validation errors found in Dataset Site JSON-LD:
         withOrdersRpdeHeaders(getOrdersFeedHeader(feedBookingPartnerIdentifier)),
         feedBookingPartnerIdentifier === 'primary' ? monitorOrdersPage(type) : () => null, // TODO: Allow monitorOrdersPage to handle multiple feedBookingPartnerIdentifier
         true,
-        multibar,
+        state.multibar,
       ));
     }
   }
@@ -1782,7 +1687,6 @@ setTimeout(() => {
 /**
  * Normalize a port into a number, string, or false.
  */
-
 function normalizePort(val) {
   const integerPort = parseInt(val, 10);
 

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -525,7 +525,7 @@ async function setFeedIsUpToDate(feedIdentifier) {
       // Remove the feed from the list
       state.incompleteFeeds.splice(index, 1);
 
-      // If the list is now empty, trigger state.pendingGetOpportunityResponses to healthcheck
+      // If all feeds are now completed, trigger responses to healthcheck
       if (state.incompleteFeeds.length === 0) {
         // Stop the validator threads as soon as we've finished harvesting - so only a subset of the results will be validated
         // Note in some circumstances threads will complete their work before terminating

--- a/packages/openactive-broker-microservice/src/apiConfig.js
+++ b/packages/openactive-broker-microservice/src/apiConfig.js
@@ -1,0 +1,26 @@
+const PORT = normalizePort(process.env.PORT || '3000');
+const MICROSERVICE_BASE_URL = `http://localhost:${PORT}`;
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+function normalizePort(val) {
+  const integerPort = parseInt(val, 10);
+
+  if (Number.isNaN(integerPort)) {
+    // named pipe
+    return val;
+  }
+
+  if (integerPort >= 0) {
+    // port number
+    return integerPort;
+  }
+
+  return false;
+}
+
+module.exports = {
+  PORT,
+  MICROSERVICE_BASE_URL,
+};

--- a/packages/openactive-broker-microservice/src/models/FeedContext.d.ts
+++ b/packages/openactive-broker-microservice/src/models/FeedContext.d.ts
@@ -1,0 +1,10 @@
+export type FeedContext = {
+  currentPage: string;
+  pages: number;
+  items: number;
+  responseTimes: number[];
+  totalItemsQueuedForValidation: number;
+  validatedItems: number;
+  sleepMode?: boolean;
+  timeToHarvestCompletion?: string;
+};

--- a/packages/openactive-broker-microservice/src/state.js
+++ b/packages/openactive-broker-microservice/src/state.js
@@ -1,0 +1,133 @@
+const { OpenActiveTestAuthKeyManager } = require('@openactive/openactive-openid-test-client');
+const config = require('config');
+const PauseResume = require('./util/pause-resume');
+const { OpportunityIdCache } = require('./util/opportunity-id-cache');
+const { log } = require('./util/log');
+const { MICROSERVICE_BASE_URL } = require('./apiConfig');
+
+/**
+ * @typedef {import('./models/FeedContext').FeedContext} FeedContext
+ * @typedef {import('./validator/async-validator')} AsyncValidatorWorker
+ */
+/**
+ * @typedef {object} PendingResponse
+ * @property {(json: any) => void} send
+ * @property {() => void} cancel
+ */
+
+const state = {
+  // MISC
+  startTime: new Date(),
+  pauseResume: new PauseResume(),
+  // AUTH
+  globalAuthKeyManager: new OpenActiveTestAuthKeyManager(log, MICROSERVICE_BASE_URL, config.get('sellers'), config.get('broker.bookingPartners')),
+  // DATASET
+  datasetSiteJson: {},
+  // TEST DATASETS
+  /**
+   * For each Test Dataset, a set of IDs of Opportunities which have been randomly generated for this Test Dataset.
+   *
+   * @type {Map<string, Set<string>>}
+   */
+  testDatasets: new Map(),
+  // HARVESTING
+  /**
+   * Harvesting state for each RPDE feed.
+   *
+   * Key = Either:
+   *   - `OrdersFeed (auth:${bookingPartnerIdentifier})` - the Orders feed for a given Booking Partner (e.g. `primary`)
+   *   - 'OrderProposalsFeed (auth:${bookingPartnerIdentifier})' - the OrderProposalsFeed for a given Booking Partner (e.g. `primary`)
+   *   - 'ScheduledSession'|'SessionSeries'|'FacilityUseSlot'|..etc - one of the Opportunity feeds.
+   *
+   * @type {Map<string, FeedContext>}
+   */
+  feedContextMap: new Map(),
+  /**
+   * List of Feed identifiers which have not yet completed harvesting.
+   *
+   * @type {string[]}
+   */
+  incompleteFeeds: [],
+  // API RESPONSES
+  /**
+   * Call `.send()` on one of these reponses in order to respond to an as-yet unanswered request to get an Opportunity
+   * with a given ID.
+   *
+   * @type {{ [opportunityId: string]: PendingResponse }}
+   */
+  pendingGetOpportunityResponses: {},
+  /**
+   * Maps Order UUIDs to a "Listener" object, which can be used to return an API response to the client which is
+   * requesting this Order UUID.
+   *
+   * @typedef {{
+   *   item: any,
+   *   collectRes: import('express').Response | null,
+   * }} Listener
+   *
+   * @type {Map<string, Listener>}
+   */
+  orderUuidListeners: new Map(),
+  // VALIDATION
+  /**
+   * Workers which perform the validation. Validation is quite expensive, so we do it with a parallel work queue.
+   *
+   * @type {AsyncValidatorWorker[]}
+   */
+  validatorThreadArray: [],
+  /**
+   * Results of opportunity validation. These are stored so that they can all be rendered to a page if there are any
+   * errors.
+   *
+   * @type {Map<string, any>}
+   */
+  validationResults: new Map(),
+  // OPPORTUNITY DATA CACHES
+  opportunityIdCache: OpportunityIdCache.create(),
+  // nSQL joins appear to be slow, even with indexes. This is an optimisation pending further investigation
+  parentOpportunityMap: new Map(),
+  parentOpportunityRpdeMap: new Map(),
+  opportunityMap: new Map(),
+  opportunityRpdeMap: new Map(),
+  rowStoreMap: new Map(),
+  parentIdIndex: new Map(),
+  // UI
+  // create new progress bar container
+  multibar: null,
+  // HEALTH CHECKS
+  /**
+   * Express responses for /health-check requests which have not yet been delivered and will be sent when the feed
+   * is fully harvested.
+   *
+   * @type {import('express').Response[]}
+   */
+  healthCheckResponsesWaitingForHarvest: [],
+};
+
+/**
+ * @param {string} testDatasetIdentifier
+ */
+function getTestDataset(testDatasetIdentifier) {
+  if (!state.testDatasets.has(testDatasetIdentifier)) {
+    state.testDatasets.set(testDatasetIdentifier, new Set());
+  }
+  return state.testDatasets.get(testDatasetIdentifier);
+}
+
+function getAllDatasets() {
+  return new Set(Array.from(state.testDatasets.values()).flatMap((x) => Array.from(x.values())));
+}
+
+/**
+ * @param {string} feedIdentifier
+ */
+function addFeed(feedIdentifier) {
+  state.incompleteFeeds.push(feedIdentifier);
+}
+
+module.exports = {
+  state,
+  getTestDataset,
+  getAllDatasets,
+  addFeed,
+};

--- a/packages/openactive-broker-microservice/src/state.js
+++ b/packages/openactive-broker-microservice/src/state.js
@@ -15,6 +15,9 @@ const { MICROSERVICE_BASE_URL } = require('./apiConfig');
  * @property {() => void} cancel
  */
 
+/**
+ * Broker's internal state.
+ */
 const state = {
   // MISC
   startTime: new Date(),

--- a/packages/openactive-broker-microservice/src/util/log.js
+++ b/packages/openactive-broker-microservice/src/util/log.js
@@ -1,0 +1,15 @@
+const chalk = require('chalk');
+
+/* eslint-disable no-console */
+const logError = (x) => console.error(chalk.cyanBright(x));
+const logErrorDuringHarvest = (x) => console.error(chalk.cyanBright(`\n\n${x}\n\n\n\n\n\n\n\n\n`));
+const log = (x) => console.log(chalk.cyan(x));
+/* eslint-enable no-console */
+const logCharacter = (x) => process.stdout.write(chalk.cyan(x));
+
+module.exports = {
+  logError,
+  logErrorDuringHarvest,
+  log,
+  logCharacter,
+};

--- a/packages/openactive-broker-microservice/tsconfig.json
+++ b/packages/openactive-broker-microservice/tsconfig.json
@@ -10,6 +10,7 @@
   },
   "include": [
     "app.js",
-    "src/util/**/*.js"
+    "src/util/**/*.js",
+    "src/*.js"
   ]
 }


### PR DESCRIPTION
Why?

* I personally find it easier to find out what's going on as previously the state was in quite a few places
* Hopefully this will make it easier in future to move broker to a place where we can separate domain logic and side effects, making it easier to test, split apart and reason about