### PR TITLE
feat(broker): Listen for Opportunity with given remainingCapacity

### DIFF
--- a/packages/openactive-broker-microservice/.eslintrc.json
+++ b/packages/openactive-broker-microservice/.eslintrc.json
@@ -34,7 +34,8 @@
         ]
       }
     ],
-    "no-use-before-define": ["error", { "functions": false, "classes": false }]
+    "no-use-before-define": ["error", { "functions": false, "classes": false }],
+    "no-underscore-dangle": "off"
   },
   "parserOptions": {
     "ecmaVersion": 2020

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -1337,11 +1337,6 @@ async function processOpportunityItem(item) {
 
     const { didRespond } = state.onePhaseListeners.opportunity.doRespondToAndDeleteListenerIfExistsAndMatchesCriteria(id, item);
 
-    // if (didRespond) {
-    //   console.log('\nYOWZA didRespond 2');
-    // } else {
-    //   console.log('nosir didNotRespond 2');
-    // }
     if (VERBOSE) {
       const bookableIssueList = unmetCriteriaDetails.length > 0
         ? `\n   [Unmet Criteria: ${Array.from(new Set(unmetCriteriaDetails)).join(', ')}]` : '';

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -1332,14 +1332,12 @@ async function processOpportunityItem(item) {
       }
     }
 
-    if (state.pendingGetOpportunityResponses[id]) {
-      state.pendingGetOpportunityResponses[id].send(item);
-    }
+    const { didRespond } = state.onePhaseListeners.opportunity.doRespondToAndDeleteListenerIfExistsAndMatchesCriteria(id, item);
 
     if (VERBOSE) {
       const bookableIssueList = unmetCriteriaDetails.length > 0
         ? `\n   [Unmet Criteria: ${Array.from(new Set(unmetCriteriaDetails)).join(', ')}]` : '';
-      if (state.pendingGetOpportunityResponses[id]) {
+      if (didRespond) {
         log(`seen ${matchingCriteria.join(', ')} and dispatched ${id}${bookableIssueList}`);
       } else {
         log(`saw ${matchingCriteria.join(', ')} ${id}${bookableIssueList}`);

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -883,7 +883,10 @@ function doOnePhaseListenForOpportunity(opportunityId, useCacheIfAvailable, does
       } else {
         log(`used cached response for "${opportunityId}"`);
       }
-      const { didRespond } = state.onePhaseListeners.opportunity.doRespondToAndDeleteListenerIfExistsAndMatchesCriteria(opportunityId, cachedResponse);
+      const { didRespond } = state.onePhaseListeners.opportunity.doRespondToAndDeleteListenerIfExistsAndMatchesCriteria(opportunityId, {
+        // Make it into an RPDE item-ish - as these are the items that onePhaseListeners.opportunity deals with.
+        data: cachedResponse,
+      });
       if (didRespond) {
         return;
       }
@@ -916,8 +919,8 @@ app.get('/opportunity/:id', function (req, res) {
   })();
   const doesItemMatchCriteria = isNil(expectedCapacity)
     ? (() => true)
-    : ((opportunity) => (
-      criteriaUtils.getRemainingCapacity(opportunity) === expectedCapacity
+    : ((rpdeItem) => (
+      criteriaUtils.getRemainingCapacity(rpdeItem.data) === expectedCapacity
     ));
   doOnePhaseListenForOpportunity(id, useCacheIfAvailable, doesItemMatchCriteria, res);
 });
@@ -1334,6 +1337,11 @@ async function processOpportunityItem(item) {
 
     const { didRespond } = state.onePhaseListeners.opportunity.doRespondToAndDeleteListenerIfExistsAndMatchesCriteria(id, item);
 
+    // if (didRespond) {
+    //   console.log('\nYOWZA didRespond 2');
+    // } else {
+    //   console.log('nosir didNotRespond 2');
+    // }
     if (VERBOSE) {
       const bookableIssueList = unmetCriteriaDetails.length > 0
         ? `\n   [Unmet Criteria: ${Array.from(new Set(unmetCriteriaDetails)).join(', ')}]` : '';

--- a/packages/openactive-broker-microservice/package-lock.json
+++ b/packages/openactive-broker-microservice/package-lock.json
@@ -4857,6 +4857,12 @@
         "@types/node": "*"
       }
     },
+    "@types/chai": {
+      "version": "4.2.22",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
+      "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
+      "dev": true
+    },
     "@types/connect": {
       "version": "3.4.34",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
@@ -4893,6 +4899,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.175",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+      "integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw==",
       "dev": true
     },
     "@types/mime": {
@@ -5026,6 +5038,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -5809,6 +5826,19 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -5817,6 +5847,11 @@
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "cli-progress": {
       "version": "3.9.0",
@@ -5980,6 +6015,14 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -6655,6 +6698,11 @@
           }
         }
       }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "get-intrinsic": {
       "version": "1.0.1",
@@ -7538,6 +7586,11 @@
         "pify": "^2.0.0"
       }
     },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -8235,6 +8288,11 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.8.1",

--- a/packages/openactive-broker-microservice/package.json
+++ b/packages/openactive-broker-microservice/package.json
@@ -21,6 +21,7 @@
     "@openactive/test-interface-criteria": "file:../test-interface-criteria",
     "await-semaphore": "^0.1.3",
     "axios": "^0.19.2",
+    "chai": "^4.3.4",
     "chalk": "^4.1.0",
     "cli-progress": "^3.9.0",
     "config": "^3.2.4",
@@ -30,6 +31,7 @@
     "htmlmetaparser": "^2.0.3",
     "htmlparser2": "^4.1.0",
     "js-base64": "^3.6.0",
+    "lodash": "^4.17.21",
     "mkdirp": "^1.0.4",
     "morgan": "~1.9.0",
     "p-memoize": "^3.1.0",
@@ -38,7 +40,9 @@
     "threads": "^1.6.3"
   },
   "devDependencies": {
+    "@types/chai": "^4.2.22",
     "@types/express": "^4.17.9",
+    "@types/lodash": "^4.14.175",
     "@types/node": "^14.6.0",
     "eslint": "^7.24.0",
     "eslint-config-airbnb": "^18.2.1",

--- a/packages/openactive-broker-microservice/src/onePhaseListeners.js
+++ b/packages/openactive-broker-microservice/src/onePhaseListeners.js
@@ -1,0 +1,74 @@
+const { log } = require('./util/log');
+
+/**
+ * @typedef {object} OnePhaseListener
+ * @property {(json: unknown) => void} send
+ * @property {() => void} cancel
+ * @property {(item: unknown) => boolean} doesItemMatchCriteria
+ */
+
+/* TODO this logic can be merged with TwoPhaseListeners, which is very similar, but just has a different internal
+interface (e.g. .collectRes(..) rather than .send(..)) */
+class OnePhaseListeners {
+  constructor() {
+    /** @type {Map<string, OnePhaseListener>} */
+    this._listeners = new Map();
+  }
+
+  /**
+   * @param {string} listenerId
+   */
+  _cancelListenerIfExists(listenerId) {
+    const listener = this._listeners.get(listenerId);
+    if (listener) {
+      listener.cancel();
+    }
+  }
+
+  /**
+   * @param {string} listenerId
+   * @param {(item: unknown) => boolean} doesItemMatchCriteria Use this to filter which items the listener will trigger
+   *   for. e.g., for a Slot, using `doesItemMatchCriteria=(slot) => slot.remainingSpaces === 2` will mean that the
+   *   is only triggered for a Slot if it has `remainingSpaces` equal to 2. This means the listener will ignore an item
+   *   with the correct ID if its `remainingSpaces` is equal to 3.
+   *   If you just want any item with matching ID to be returned, regardless of its data, pass in `() => true`.
+   * @param {import('express').Response} res
+   */
+  createListener(listenerId, doesItemMatchCriteria, res) {
+    this._cancelListenerIfExists(listenerId);
+    this._listeners.set(listenerId, {
+      send: (json) => {
+        res.json(json);
+      },
+      cancel: () => {
+        log(`Ignoring previous request for One-Phase Listener: "${listenerId}"`);
+        res.status(400).json({
+          error: `A newer request to wait for One-Phase Listener "${listenerId}" has been received, so this request has been cancelled.`,
+        });
+      },
+      doesItemMatchCriteria,
+    });
+  }
+
+  /**
+   * @param {string} listenerId
+   * @param {unknown} item
+   */
+  doRespondToAndDeleteListenerIfExistsAndMatchesCriteria(listenerId, item) {
+    const listener = this._listeners.get(listenerId);
+    if (listener && listener.doesItemMatchCriteria(item)) {
+      listener.send(item);
+      this._listeners.delete(listenerId);
+      return {
+        didRespond: true,
+      };
+    }
+    return {
+      didRespond: false,
+    };
+  }
+}
+
+module.exports = {
+  OnePhaseListeners,
+};

--- a/packages/openactive-broker-microservice/src/order-uuid-tracking/api.js
+++ b/packages/openactive-broker-microservice/src/order-uuid-tracking/api.js
@@ -1,5 +1,5 @@
-const { error409IfListenerAlreadyExists } = require('../listeners/api');
-const { Listeners } = require('../listeners/listeners');
+const { error409IfListenerAlreadyExists } = require('../twoPhaseListeners/api');
+const { TwoPhaseListeners: Listeners } = require('../twoPhaseListeners/twoPhaseListeners');
 const { state } = require('../state');
 const { error400IfExpressParamsAreMissing } = require('../util/api-utils');
 const { orderFeedContextIdentifier } = require('../util/feed-context-identifier');

--- a/packages/openactive-broker-microservice/src/order-uuid-tracking/order-uuid-tracking.js
+++ b/packages/openactive-broker-microservice/src/order-uuid-tracking/order-uuid-tracking.js
@@ -1,5 +1,5 @@
 const { ORDERS_FEED_IDENTIFIER, ORDER_PROPOSALS_FEED_IDENTIFIER } = require('../broker-config');
-const { Listeners } = require('../listeners/listeners');
+const { TwoPhaseListeners: Listeners } = require('../twoPhaseListeners/twoPhaseListeners');
 const { orderFeedContextIdentifier } = require('../util/feed-context-identifier');
 
 /**

--- a/packages/openactive-broker-microservice/src/state.js
+++ b/packages/openactive-broker-microservice/src/state.js
@@ -91,7 +91,11 @@ const state = {
    * item (e.g. an Opportunity), and an HTTP response is triggered if the item is found.
    */
   onePhaseListeners: {
-    /** Uses Opportunity ID as Listener ID */
+    /**
+     * One-phase Listeners for Opportunities.
+     * - Listener ID: Opportunity ID
+     * - Item: Opportunity RPDE Item (e.g. `{ data: { '@type': 'Slot', ...} }`)
+     */
     opportunity: new OnePhaseListeners(),
   },
   orderUuidTracking: OrderUuidTracking.createState(),

--- a/packages/openactive-broker-microservice/src/state.js
+++ b/packages/openactive-broker-microservice/src/state.js
@@ -56,13 +56,6 @@ const state = {
   incompleteFeeds: [],
   // API RESPONSES
   /**
-   * Call `.send()` on one of these reponses in order to respond to an as-yet unanswered request to get an Opportunity
-   * with a given ID.
-   *
-   * @type {{ [opportunityId: string]: PendingResponse }}
-   */
-  pendingGetOpportunityResponses: {},
-  /**
    * Maps Listener ID => a "Listener" object, which can be used to return an API response to the client
    * which is listening for this item.
    *

--- a/packages/openactive-broker-microservice/src/state.js
+++ b/packages/openactive-broker-microservice/src/state.js
@@ -1,11 +1,12 @@
 const { OpenActiveTestAuthKeyManager } = require('@openactive/openactive-openid-test-client');
 const config = require('config');
-const { Listeners } = require('./listeners/listeners');
+const { TwoPhaseListeners: Listeners } = require('./twoPhaseListeners/twoPhaseListeners');
 const PauseResume = require('./util/pause-resume');
 const { OpportunityIdCache } = require('./util/opportunity-id-cache');
 const { log } = require('./util/log');
 const { MICROSERVICE_BASE_URL } = require('./broker-config');
 const { OrderUuidTracking } = require('./order-uuid-tracking/order-uuid-tracking');
+const { OnePhaseListeners } = require('./onePhaseListeners');
 
 /**
  * @typedef {import('./models/core').FeedContext} FeedContext
@@ -62,14 +63,14 @@ const state = {
    */
   pendingGetOpportunityResponses: {},
   /**
-   * Maps Order UUIDs to a "Listener" object, which can be used to return an API response to the client which is
-   * requesting this Order UUID.
+   * Maps Listener ID => a "Listener" object, which can be used to return an API response to the client
+   * which is listening for this item.
+   *
+   * These are called 2-phase listeners because the listening and collection happen as two separate API calls (a POST
+   * to set up the listener and a GET to retrieve the found item).
    *
    * When Broker gets a request to listen for a particular Opportunity or Order, it creates a "Listener" object,
    * which can later be used to return an API response to the client which is listening for this item.
-   *
-   * `listeners` maps Listener ID => a "Listener" object, which can be used to return an API response to the client
-   * which is listening for this item.
    *
    * A "Listener ID" takes either of the forms:
    *
@@ -77,7 +78,7 @@ const state = {
    * - `orders::{bookingPartnerIdentifier}::{orderUuid}` e.g. `orders::primary::4324d932-a326-4cc7-bcc0-05fb491744c7`
    * - `order-proposals::{bookingPartnerIdentifier}::{orderUuid}`
    */
-  listeners: {
+  twoPhaseListeners: {
     /**
      * Maps `{type}::{bookingPartnerIdentifier}::{orderUuid}` to a "Listener" where `type` is one of `orders` or
      * `order-proposals`.
@@ -89,6 +90,16 @@ const state = {
      * Maps Opportunity ID to a "Listener"
      */
     byOpportunityId: Listeners.createListenersMap(),
+  },
+  /**
+   * These are called 1-phase listeners because the listening and collection happen as one API call.
+   *
+   * Otherwise, though, it is very similar to the twoPhaseListeners. A "Listener" is set up to listen for a particular
+   * item (e.g. an Opportunity), and an HTTP response is triggered if the item is found.
+   */
+  onePhaseListeners: {
+    /** Uses Opportunity ID as Listener ID */
+    opportunity: new OnePhaseListeners(),
   },
   orderUuidTracking: OrderUuidTracking.createState(),
   // VALIDATION

--- a/packages/openactive-broker-microservice/src/twoPhaseListeners/twoPhaseListeners.js
+++ b/packages/openactive-broker-microservice/src/twoPhaseListeners/twoPhaseListeners.js
@@ -9,7 +9,7 @@
  * @typedef {Map<string, Listener>} ListenersMap
  */
 
-const Listeners = {
+const TwoPhaseListeners = {
   /**
    * @param {OrderFeedType} type
    * @param {string} bookingPartnerIdentifier
@@ -96,15 +96,15 @@ const Listeners = {
       const { collectRes } = listenersMap.get(listenerId);
       // If there's already a collection request, fulfill it
       if (collectRes) {
-        Listeners.doRespondToAndDeleteListener(listenersMap, listenerId, collectRes, item);
+        TwoPhaseListeners.doRespondToAndDeleteListener(listenersMap, listenerId, collectRes, item);
       } else {
         // If not, set the opportunity so that it can returned when the collection call arrives
-        listenersMap.set(listenerId, Listeners.createResolvedButNotPendingListener(item));
+        listenersMap.set(listenerId, TwoPhaseListeners.createResolvedButNotPendingListener(item));
       }
     }
   },
 };
 
 module.exports = {
-  Listeners,
+  TwoPhaseListeners,
 };

--- a/packages/test-interface-criteria/built-types/index.d.ts
+++ b/packages/test-interface-criteria/built-types/index.d.ts
@@ -93,7 +93,9 @@ export function getTestDataShapeExpressions(criteriaName: string, bookingFlow: '
     }[];
 };
 declare const getOrganizerOrProvider: (opportunity: import("./types/Opportunity").Opportunity) => any;
+declare const getRemainingCapacity: (opportunity: import("./types/Opportunity").Opportunity) => number;
 export declare namespace utils {
     export { getOrganizerOrProvider };
+    export { getRemainingCapacity };
 }
 export { allCriteria as criteria };

--- a/packages/test-interface-criteria/src/index.js
+++ b/packages/test-interface-criteria/src/index.js
@@ -5,7 +5,7 @@
 const { memoize } = require('lodash');
 const { DateTime } = require('luxon');
 const { allCriteria } = require('./criteria');
-const { getOrganizerOrProvider, extendTestDataShape } = require('./criteria/criteriaUtils');
+const { getOrganizerOrProvider, extendTestDataShape, getRemainingCapacity } = require('./criteria/criteriaUtils');
 const { openBookingFlowRequirementArrayConstraint } = require('./testDataShape');
 
 /**
@@ -176,5 +176,6 @@ module.exports = {
   // Utils
   utils: {
     getOrganizerOrProvider,
+    getRemainingCapacity,
   },
 };


### PR DESCRIPTION
Functionality in Broker to listen for an Opportunity and only return when it finds that Opportunity with the expected remainingCapacity

Relates to https://github.com/openactive/openactive-test-suite/issues/460

## QA

Used with `expectedCapacity=<the actual amount that it's at>`. It returns correctly 👍 

![Screenshot 2021-09-28 at 15 15 23](https://user-images.githubusercontent.com/2067438/135105214-48ebd687-d0c1-48eb-87ea-422ec52c4407.png)

Used with `expectedCapacity=<a different amount than it actually is at>`. It just waits until timeout. Here it is waiting for a bit:

https://user-images.githubusercontent.com/2067438/135105418-cb3e0af2-a09e-4d47-a13b-23cd6789c2c6.mov