### PR TITLE
fix(broker): Read validator input file in worker rather than in worker pool

### DIFF
--- a/packages/openactive-broker-microservice/src/validator/validator-worker-pool.js
+++ b/packages/openactive-broker-microservice/src/validator/validator-worker-pool.js
@@ -149,9 +149,8 @@ class ValidatorWorkerPool {
    * @param {string} filePath
    */
   async _validateFileWithWorker(filePath) {
-    const fileData = await fs.readFile(filePath);
     const worker = new Worker(workerFileName, {
-      workerData: fileData.toString(),
+      workerData: filePath,
     });
     await new Promise((resolve, reject) => {
       worker.on('message', (/** @type {ValidatorWorkerResponse} */message) => {

--- a/packages/openactive-broker-microservice/src/validator/validator-worker.js
+++ b/packages/openactive-broker-microservice/src/validator/validator-worker.js
@@ -1,4 +1,5 @@
 const { validate } = require('@openactive/data-model-validator');
+const fs = require('fs').promises;
 const { execPipe, filter, toArray, map } = require('iter-tools');
 const { workerData, parentPort } = require('worker_threads');
 const { silentlyAllowInsecureConnections } = require('../util/suppress-unauthorized-warning');
@@ -12,9 +13,11 @@ const { VALIDATOR_TMP_DIR } = require('../broker-config');
 silentlyAllowInsecureConnections();
 
 async function run() {
+  const filePath = workerData;
+  const fileData = await fs.readFile(filePath);
   // JSON parsing is included in the validatorWorker as it's CPU intensive
   /** @type {ValidatorWorkerRequestParsed} */
-  const requestParsed = JSON.parse(workerData);
+  const requestParsed = JSON.parse(fileData.toString());
   /** @type {ValidatorWorkerResponse['numItemsPerFeed']} */
   const numItemsPerFeed = {};
   /** @type {ValidatorWorkerResponse['errors']} */


### PR DESCRIPTION
This means that the worker pool only needs to send the file path to the worker rather than the whole file, which gets cloned.

This seems to also fix an intermittent issue in which validator input data is sometimes truncated (and therefore fails JSON parsing)

---

I've not been able to find anything about node.js truncating `workerData` input, but I've empirically seen it happen on my machine (sometimes). It seems that, under certain circumstances (?) it may impose a length limit on the data that it sends.

Regardless, now that I've learned that `workerData` is cloned before sending to a worker (https://nodejs.org/api/worker_threads.html#workerworkerdata), the code herein should be somewhat more optimised as it is only a file path that is cloned rather than a string containing 100 opportunities!

## QA

**BEFORE** An instance of the intermittent issue appearing when running broker - see that the workerData input is truncated, which causes the issue:

![Screenshot 2022-02-25 at 14 52 00](https://user-images.githubusercontent.com/2067438/155739231-49fc7962-be51-4b3f-91ae-9aac7e37f558.png)

**AFTER** I've run Broker 10 times since making this change and it hasn't broken in this way since