### PR TITLE
fix: add openBookingInAdvance constraint to TestOpportunityBookableOu…

### DIFF
--- a/packages/test-interface-criteria/src/criteria/TestOpportunityBookableOutsideValidFromBeforeStartDate.js
+++ b/packages/test-interface-criteria/src/criteria/TestOpportunityBookableOutsideValidFromBeforeStartDate.js
@@ -1,4 +1,4 @@
-const { getDateAfterWhichBookingsCanBeMade, remainingCapacityMustBeAtLeastTwo, createCriteria } = require('./criteriaUtils');
+const { getDateAfterWhichBookingsCanBeMade, remainingCapacityMustBeAtLeastTwo, createCriteria, mustNotBeOpenBookingInAdvanceUnavailable } = require('./criteriaUtils');
 const { dateRange, shapeConstraintRecipes } = require('../testDataShape');
 const { InternalCriteriaFutureScheduledAndDoesNotRequireDetails } = require('./internal/InternalCriteriaFutureScheduledAndDoesNotRequireDetails');
 
@@ -32,6 +32,10 @@ const TestOpportunityBookableOutsideValidFromBeforeStartDate = createCriteria({
     ],
   ],
   offerConstraints: [
+    [
+      'openBookingInAdvance of offer must not be `https://openactive.io/Unavailable`',
+      mustNotBeOpenBookingInAdvanceUnavailable,
+    ],
     [
       'Must be outside booking window (`validFromBeforeStartDate`)',
       mustHaveBookingWindowAndBeOutsideOfIt,


### PR DESCRIPTION
…tsideValidFromBeforeStartDate

For this test, the offer must be theoretically bookable but currently outside the booking window. This test was picking offers that were not theoretically bookable (openBookingInAdvance: https://openactive.io/Unavailable)