### PR TITLE
feat: Auto-restart broker

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node start.js",
     "debug": "node --inspect start.js -- --runInBand",
     "start-broker": "cd packages/openactive-broker-microservice && npm start",
+    "start-broker-with-auto-restart": "cd packages/openactive-broker-microservice; while true; do npm start; done",
     "validate-feeds": "cd packages/openactive-broker-microservice && npm run validate-feeds",
     "start-tests": "cd packages/openactive-integration-tests && npm start",
     "install-broker": "cd packages/openactive-broker-microservice && npm install",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node start.js",
     "debug": "node --inspect start.js -- --runInBand",
     "start-broker": "cd packages/openactive-broker-microservice && npm start",
-    "start-broker-with-auto-restart": "cd packages/openactive-broker-microservice && npm auto-restart",
+    "start-broker-with-auto-restart": "cd packages/openactive-broker-microservice && npm run auto-restart",
     "validate-feeds": "cd packages/openactive-broker-microservice && npm run validate-feeds",
     "start-tests": "cd packages/openactive-integration-tests && npm start",
     "install-broker": "cd packages/openactive-broker-microservice && npm install",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node start.js",
     "debug": "node --inspect start.js -- --runInBand",
     "start-broker": "cd packages/openactive-broker-microservice && npm start",
-    "start-broker-with-auto-restart": "cd packages/openactive-broker-microservice; while true; do npm start; done",
+    "start-broker-with-auto-restart": "cd packages/openactive-broker-microservice && npm auto-restart",
     "validate-feeds": "cd packages/openactive-broker-microservice && npm run validate-feeds",
     "start-tests": "cd packages/openactive-integration-tests && npm start",
     "install-broker": "cd packages/openactive-broker-microservice && npm install",

--- a/packages/openactive-broker-microservice/auto-restart.sh
+++ b/packages/openactive-broker-microservice/auto-restart.sh
@@ -4,6 +4,5 @@
 
 while true; do
     npm start
-    echo "openactive-broker-microservice exited with status $?. Restarting in 10 seconds..."
-    sleep 10
+    echo "openactive-broker-microservice exited with status $?. Restarting..."
 done

--- a/packages/openactive-broker-microservice/auto-restart.sh
+++ b/packages/openactive-broker-microservice/auto-restart.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# auto-restart.sh allows the broker to restart itself if it crashes (e.g if its buckets expire), which is useful in some deployment scenarios.
+
+while true; do
+    npm start
+    echo "openactive-broker-microservice exited with status $?. Restarting in 10 seconds..."
+    sleep 10
+done

--- a/packages/openactive-broker-microservice/package.json
+++ b/packages/openactive-broker-microservice/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "auto-restart": "while true; npm start; done",
+    "auto-restart": "./auto-restart.sh",
     "validate-feeds": "node app.js --validate-only",
     "test": "npm run lint && tsc",
     "debug": "node --inspect app.js",

--- a/packages/openactive-broker-microservice/package.json
+++ b/packages/openactive-broker-microservice/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "auto-restart": "./auto-restart.sh",
+    "auto-restart": "while true; npm start; done",
     "validate-feeds": "node app.js --validate-only",
     "test": "npm run lint && tsc",
     "debug": "node --inspect app.js",

--- a/packages/openactive-broker-microservice/package.json
+++ b/packages/openactive-broker-microservice/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
+    "auto-restart": "./auto-restart.sh",
     "validate-feeds": "node app.js --validate-only",
     "test": "npm run lint && tsc",
     "debug": "node --inspect app.js",


### PR DESCRIPTION
Allows the broker to restart itself if it crashes (e.g if its buckets expire), which is useful in some deployment scenarios