### PR TITLE
feat: get broker booking partner identifiers from config

### DIFF
--- a/packages/openactive-broker-microservice/README.md
+++ b/packages/openactive-broker-microservice/README.md
@@ -158,7 +158,7 @@ While debugging authentication it can be useful to log the configuration that th
 
 Config for [Booking Partners](https://openactive.io/open-booking-api/EditorsDraft/1.0CR3/#dfn-booking-partner) that the Test Suite will use to connect to your Booking System.
 
-Broker uses two Booking Partners, named `primary` and `secondary`.
+When running Broker Microservice with [Integration Tests](../openactive-integration-tests/) (which is the primary usage of Broker Microservice), you muse define two Booking Partners, named `primary` and `secondary`.
 
 ```json
   "bookingPartners": {
@@ -177,6 +177,8 @@ Broker uses two Booking Partners, named `primary` and `secondary`.
     }
   }
 ```
+
+However, when running Broker Microservice as a standalone app, you may define any number of Booking Partners, with whatever identifiers you like e.g. `acme1`, `acme2` and `acme3` instead of `primary` and `secondary`. Just know that these will NOT work with the [Integration Tests](../openactive-integration-tests/), which expect only `primary` and `secondary`.
 
 The `authentication` field can contain one of several different authentication strategies for authenticating as the Booking Partner for Order and Order Proposal RPDE Feed requests. Set only one of these strategies. The different authentication strategies are documented in the below subsections.
 

--- a/packages/openactive-broker-microservice/README.md
+++ b/packages/openactive-broker-microservice/README.md
@@ -178,7 +178,7 @@ When running Broker Microservice with [Integration Tests](../openactive-integrat
   }
 ```
 
-However, when running Broker Microservice as a standalone app, you may define any number of Booking Partners, with whatever identifiers you like e.g. `acme1`, `acme2` and `acme3` instead of `primary` and `secondary`. Just know that these will NOT work with the [Integration Tests](../openactive-integration-tests/), which expect only `primary` and `secondary`.
+When running Broker Microservice as a standalone app, any number of Booking Partners may be defined e.g. `acme1`, `acme2` and `acme3` instead of `primary` and `secondary`. Note that these will _not_ work with the [Integration Tests](../openactive-integration-tests/), which expect only `primary` and `secondary`.
 
 The `authentication` field can contain one of several different authentication strategies for authenticating as the Booking Partner for Order and Order Proposal RPDE Feed requests. Set only one of these strategies. The different authentication strategies are documented in the below subsections.
 

--- a/packages/openactive-broker-microservice/README.md
+++ b/packages/openactive-broker-microservice/README.md
@@ -158,7 +158,7 @@ While debugging authentication it can be useful to log the configuration that th
 
 Config for [Booking Partners](https://openactive.io/open-booking-api/EditorsDraft/1.0CR3/#dfn-booking-partner) that the Test Suite will use to connect to your Booking System.
 
-When running Broker Microservice with [Integration Tests](../openactive-integration-tests/) (which is the primary usage of Broker Microservice), you muse define two Booking Partners, named `primary` and `secondary`.
+When running Broker Microservice with [Integration Tests](../openactive-integration-tests/) (which is the primary usage of Broker Microservice), you must define two Booking Partners, named `primary` and `secondary`.
 
 ```json
   "bookingPartners": {

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -1677,9 +1677,7 @@ Validation errors found in Dataset Site JSON-LD:
           baseUrl: feedUrl,
           feedContextIdentifier,
           headers: withOrdersRpdeHeaders(getOrdersFeedHeader(feedBookingPartnerIdentifier)),
-          processPage: feedBookingPartnerIdentifier === 'primary'
-            ? monitorOrdersPage(type, feedBookingPartnerIdentifier)
-            : () => null,
+          processPage: monitorOrdersPage(type, feedBookingPartnerIdentifier),
           isOrdersFeed: true,
           bar: state.multibar,
           processEndOfFeed: () => {

--- a/packages/openactive-broker-microservice/app.js
+++ b/packages/openactive-broker-microservice/app.js
@@ -60,6 +60,7 @@ const {
   CONSOLE_OUTPUT_LEVEL,
   HEADLESS_AUTH,
   VALIDATOR_TMP_DIR,
+  BOOKING_PARTNER_IDENTIFIERS,
 } = require('./src/broker-config');
 const { getIsOrderUuidPresentApi } = require('./src/order-uuid-tracking/api');
 const { createOpportunityListenerApi, getOpportunityListenerApi, createOrderListenerApi, getOrderListenerApi } = require('./src/twoPhaseListeners/api');
@@ -1652,14 +1653,9 @@ Validation errors found in Dataset Site JSON-LD:
     }
   });
 
-  /**
-   *  @type {BookingPartnerIdentifier[]}
-   */
-  const bookingPartnerIdentifiers = ['primary', 'secondary'];
-
   // Only poll orders feed if included in the dataset site
   if (!VALIDATE_ONLY && !DO_NOT_HARVEST_ORDERS_FEED && dataset.accessService && dataset.accessService.endpointUrl) {
-    for (const { feedUrl, type, feedContextIdentifier, bookingPartnerIdentifier: feedBookingPartnerIdentifier } of bookingPartnerIdentifiers.flatMap((bookingPartnerIdentifier) => [
+    for (const { feedUrl, type, feedContextIdentifier, bookingPartnerIdentifier: feedBookingPartnerIdentifier } of BOOKING_PARTNER_IDENTIFIERS.flatMap((bookingPartnerIdentifier) => [
       {
         feedUrl: `${dataset.accessService.endpointUrl}/orders-rpde`,
         type: /** @type {OrderFeedType} */('orders'),

--- a/packages/openactive-broker-microservice/src/broker-config.js
+++ b/packages/openactive-broker-microservice/src/broker-config.js
@@ -27,6 +27,7 @@ const ORDER_PROPOSALS_FEED_IDENTIFIER = 'OrderProposalsFeed';
 
 const BOOKING_PARTNER_IDENTIFIERS = Object.entries(config.get('broker.bookingPartners')).map(([key, value]) => {
   if (value) return key;
+  return null;
 }).filter(Boolean);
 
 // These options are not recommended for general use, but are available for specific test environment configuration and debugging

--- a/packages/openactive-broker-microservice/src/broker-config.js
+++ b/packages/openactive-broker-microservice/src/broker-config.js
@@ -25,6 +25,10 @@ const ORDERS_FEED_IDENTIFIER = 'OrdersFeed';
 /** @type {import('./models/core').OrderFeedIdentifier} */
 const ORDER_PROPOSALS_FEED_IDENTIFIER = 'OrderProposalsFeed';
 
+const BOOKING_PARTNER_IDENTIFIERS = Object.entries(config.get('broker.bookingPartners')).map(([key, value]) => {
+  if (value) return key;
+}).filter(Boolean);
+
 // These options are not recommended for general use, but are available for specific test environment configuration and debugging
 const OPPORTUNITY_FEED_REQUEST_HEADERS = config.has('broker.opportunityFeedRequestHeaders') ? config.get('broker.opportunityFeedRequestHeaders') : {};
 const DATASET_DISTRIBUTION_OVERRIDE = config.has('broker.datasetDistributionOverride') ? config.get('broker.datasetDistributionOverride') : [];
@@ -92,4 +96,5 @@ module.exports = {
   HEADLESS_AUTH,
   VALIDATOR_TMP_DIR,
   VALIDATOR_INPUT_TMP_DIR,
+  BOOKING_PARTNER_IDENTIFIERS,
 };

--- a/packages/openactive-broker-microservice/src/models/core.d.ts
+++ b/packages/openactive-broker-microservice/src/models/core.d.ts
@@ -2,7 +2,7 @@ import { SingleBar } from 'cli-progress';
 
 export type OrderFeedType = 'orders' | 'order-proposals';
 export type OrderFeedIdentifier = 'OrdersFeed' | 'OrderProposalsFeed';
-export type BookingPartnerIdentifier = 'primary' | 'secondary';
+export type BookingPartnerIdentifier = string;
 
 export type FeedContext = {
   currentPage: string;


### PR DESCRIPTION
Currently the Booking Partner identifiers are hardcoded to be `primary` and `secondary` regardless of if these are set in config. When there was no `secondary` booking partner config set, this results in requests hitting the maximum retries and the app crashing. 
This fix gets the booking partner identifiers from config and only uses the ones set there.

Before
<img width="931" alt="Screenshot 2023-07-07 at 17 22 06" src="https://github.com/openactive/openactive-test-suite/assets/16168907/d9171fdf-d7a4-457d-9022-76177a2f955b">

Now:
<img width="1011" alt="Screenshot 2023-07-07 at 17 18 04" src="https://github.com/openactive/openactive-test-suite/assets/16168907/80eb26c9-604a-41f1-ad53-ae88d1a94ac6">
