### PR TITLE
Revert "Update data models"

### DIFF
--- a/packages/openactive-broker-microservice/package-lock.json
+++ b/packages/openactive-broker-microservice/package-lock.json
@@ -161,16 +161,16 @@
       },
       "dependencies": {
         "@types/lodash": {
-          "version": "4.14.198",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-          "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg=="
+          "version": "4.14.195",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+          "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
         }
       }
     },
     "@openactive/data-models": {
-      "version": "2.0.307",
-      "resolved": "https://registry.npmjs.org/@openactive/data-models/-/data-models-2.0.307.tgz",
-      "integrity": "sha512-ncBowO/+DOWxIFvYWAWenRJg/jGo62ysy1SStOlowhXdBgF6lWTCWExfg82wo1Af2J6b7w9E+BHX8uB1+ZpubA=="
+      "version": "2.0.301",
+      "resolved": "https://registry.npmjs.org/@openactive/data-models/-/data-models-2.0.301.tgz",
+      "integrity": "sha512-ND5lnDmlXFhWgkw/XaQFK+yYHrpX5+5Hn0XMRwIMJSJyCdw+Vbrziwtw+Ng7lt1VsVsS0XSOYJu8uyOrAphaOg=="
     },
     "@openactive/openactive-openid-test-client": {
       "version": "file:../openactive-openid-test-client",
@@ -6694,9 +6694,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -7115,9 +7115,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         }
       }
     },

--- a/packages/openactive-broker-microservice/package.json
+++ b/packages/openactive-broker-microservice/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@openactive/data-model-validator": "^2.0.68",
-    "@openactive/data-models": "^2.0.307",
+    "@openactive/data-models": "^2.0.301",
     "@openactive/openactive-openid-test-client": "file:../openactive-openid-test-client",
     "@openactive/rpde-validator": "^2.0.17",
     "@openactive/test-interface-criteria": "file:../test-interface-criteria",

--- a/packages/openactive-integration-tests/package-lock.json
+++ b/packages/openactive-integration-tests/package-lock.json
@@ -944,9 +944,9 @@
       },
       "dependencies": {
         "@types/lodash": {
-          "version": "4.14.198",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-          "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg=="
+          "version": "4.14.195",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+          "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
         },
         "lodash": {
           "version": "4.17.21",
@@ -956,9 +956,9 @@
       }
     },
     "@openactive/data-models": {
-      "version": "2.0.307",
-      "resolved": "https://registry.npmjs.org/@openactive/data-models/-/data-models-2.0.307.tgz",
-      "integrity": "sha512-ncBowO/+DOWxIFvYWAWenRJg/jGo62ysy1SStOlowhXdBgF6lWTCWExfg82wo1Af2J6b7w9E+BHX8uB1+ZpubA=="
+      "version": "2.0.301",
+      "resolved": "https://registry.npmjs.org/@openactive/data-models/-/data-models-2.0.301.tgz",
+      "integrity": "sha512-ND5lnDmlXFhWgkw/XaQFK+yYHrpX5+5Hn0XMRwIMJSJyCdw+Vbrziwtw+Ng7lt1VsVsS0XSOYJu8uyOrAphaOg=="
     },
     "@openactive/openactive-openid-test-client": {
       "version": "file:../openactive-openid-test-client",
@@ -12563,9 +12563,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/packages/openactive-integration-tests/package.json
+++ b/packages/openactive-integration-tests/package.json
@@ -18,7 +18,7 @@
   "eslintConfig": {},
   "dependencies": {
     "@openactive/data-model-validator": "^2.0.68",
-    "@openactive/data-models": "^2.0.307",
+    "@openactive/data-models": "^2.0.301",
     "@openactive/openactive-openid-test-client": "file:../openactive-openid-test-client",
     "@openactive/test-interface-criteria": "file:../test-interface-criteria",
     "async-mutex": "^0.3.1",


### PR DESCRIPTION
Reverts openactive/openactive-test-suite#556

This needs to be reverted until `value` is removed from `accessCode` PropertyValues in OpenActive.Server.NET. Otherwise, most tests fail when run against OpenActive.Server.NET, which means that the CI of both projects is broken

This revert can be un-reverted once this issue has been complete: https://github.com/openactive/OpenActive.Server.NET/issues/213