### PR TITLE
fix(test-data-generator): Show Shape Expressions if integrationTests.useShapeExpressions is configured

### DIFF
--- a/packages/openactive-integration-tests/test-data-generator/test-data-generator.js
+++ b/packages/openactive-integration-tests/test-data-generator/test-data-generator.js
@@ -56,6 +56,7 @@ const DEFAULT_OUTPUT_DIR = path.join(__dirname, 'output');
 // # Constants - Config
 const IMPLEMENTED_FEATURES = getConfigVarOrThrow('integrationTests', 'implementedFeatures');
 const BOOKABLE_OPPORTUNITY_TYPES_IN_SCOPE_OBJ = getConfigVarOrThrow('integrationTests', 'bookableOpportunityTypesInScope');
+const USE_SHAPE_EXPRESSIONS = getConfigVarOrThrow('integrationTests', 'useShapeExpressions');
 /** An array of those opportunity types which the Booking System is testing */
 const IMPLEMENTED_OPPORTUNITY_TYPES = Object.entries(BOOKABLE_OPPORTUNITY_TYPES_IN_SCOPE_OBJ)
   .filter(([, isInScope]) => isInScope)
@@ -148,6 +149,10 @@ function createOutputOpportunityTestData(sellerRequirements) {
             sellerId: seller['@id'],
             sellerType: seller['@type'],
             harvestStartTimeOverride,
+            // This must be specified here as the global will not be available
+            // to `createTestInterfaceOpportunity`, as this is set up in
+            // testEnvironment.js, which is only evaluated for jest test runs.
+            useShapeExpressions: USE_SHAPE_EXPRESSIONS,
           });
           itemListElement.push({
             '@type': 'ListItem',

--- a/packages/openactive-integration-tests/test/helpers/test-interface-opportunities.js
+++ b/packages/openactive-integration-tests/test/helpers/test-interface-opportunities.js
@@ -18,9 +18,18 @@ const { HARVEST_START_TIME, USE_SHAPE_EXPRESSIONS } = global;
  * @param {string | null} [args.sellerType]
  * @param {string | null} [args.harvestStartTimeOverride] If provided, this value will be used instead of the
  *   global HARVEST_START_TIME.
+ * @param {boolean} [args.useShapeExpressions] If unspecified, the global USE_SHAPE_EXPRESSIONS will be used.
  * @returns {TestInterfaceOpportunity}
  */
-function createTestInterfaceOpportunity({ opportunityType, testOpportunityCriteria, bookingFlow, sellerId = null, sellerType = null, harvestStartTimeOverride = null }) {
+function createTestInterfaceOpportunity({
+  opportunityType,
+  testOpportunityCriteria,
+  bookingFlow,
+  sellerId = null,
+  sellerType = null,
+  harvestStartTimeOverride = null,
+  useShapeExpressions = USE_SHAPE_EXPRESSIONS,
+}) {
   const testDataShapeExpressions = getTestDataShapeExpressions(
     testOpportunityCriteria,
     bookingFlow,
@@ -36,7 +45,7 @@ function createTestInterfaceOpportunity({ opportunityType, testOpportunityCriter
     'test:testOpportunityCriteria': `https://openactive.io/test-interface#${testOpportunityCriteria}`,
     // e.g. OpenBookingApprovalFlow -> https://openactive.io/test-interface#OpenBookingApprovalFlow
     'test:testOpenBookingFlow': `https://openactive.io/test-interface#${bookingFlow}`,
-    ...(USE_SHAPE_EXPRESSIONS ? {
+    ...(useShapeExpressions ? {
       'test:testOpportunityDataShapeExpression': testDataShapeExpressions['test:testOpportunityDataShapeExpression'],
       'test:testOfferDataShapeExpression': testDataShapeExpressions['test:testOfferDataShapeExpression'],
     } : {}),


### PR DESCRIPTION
Relates to https://github.com/openactive/test-interface/issues/21

Previously, even if useShapeExpressions was configured to true, Test Data Generator would not output shape expressions. This would have been a bug introduced by https://github.com/openactive/openactive-test-suite/pull/588.

This PR fixes that