### PR TITLE
fix: Update GitHub Actions references to latest versions

### DIFF
--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
     - name: Checkout OpenActive Test Suite
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup Node.js 18.17.1
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 18.17.1
     - name: Install OpenActive Test Suite

--- a/.github/workflows/create-data-model-pr.yaml
+++ b/.github/workflows/create-data-model-pr.yaml
@@ -11,13 +11,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: master
           path: openactive-test-suite
 
       - name: Setup Node.js 18.17.1
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 18.17.1
         

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
       REGISTRY: ghcr.io
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -52,9 +52,9 @@ jobs:
 
     steps:
     - name: Checkout OpenActive Test Suite
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup Node.js 18.17.1
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 18.17.1
     - name: Install OpenActive Test Suite

--- a/.github/workflows/reference-implementation.yml
+++ b/.github/workflows/reference-implementation.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout OpenActive Test Suite
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: tests
     - name: Use matching coverage/* branch ${{ github.head_ref }} in OpenActive.Server.NET
@@ -37,19 +37,19 @@ jobs:
       id: refs
       run: echo "::set-output name=mirror_ref::${{ github.head_ref }}"
     - name: Checkout OpenActive.Server.NET ${{ steps.refs.outputs.mirror_ref }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: openactive/OpenActive.Server.NET
         ref: ${{ steps.refs.outputs.mirror_ref }}
         path: server
 
     - name: Setup .NET Core SDK 3.1.419
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 3.1.419
 
     - name: Setup Node.js 18.17.1
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 18.17.1
 
@@ -87,7 +87,7 @@ jobs:
     # 1. So that the `deploy-output` job can use this output in order to publish it, as examples, to gh-pages
     # 2. Make the artifact downloadable from GitHub to a developer so that they can debug
     - name: Upload test output for ${{ matrix.mode }} mode as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ success() || failure() }}
       with:
         name: ${{ matrix.mode }}.${{ matrix.profile }}.${{ matrix.flow }}
@@ -103,16 +103,16 @@ jobs:
     steps:
     # Checkout the repo to seed the contents of ./tests/publish/
     - name: Checkout OpenActive Test Suite
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: tests
     - name: Download test output for Random Mode
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: random.all-features.both
         path: ./tests/publish/example-output/random/
     - name: Download test output for Controlled Mode
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: controlled.all-features.both
         path: ./tests/publish/example-output/controlled/


### PR DESCRIPTION
Update GitHub Actions references to resolve deprecation errors

![Screenshot 2024-10-08 at 11 10 31](https://github.com/user-attachments/assets/5aa64b50-e13b-4bbe-b0d8-392050ba45dc)
