### PR TITLE
feat: Use ListenerItemExpectations for customer cancel

### DIFF
--- a/packages/openactive-integration-tests/test/features/cancellation/customer-requested-cancellation/implemented/atomic-cancel-test.js
+++ b/packages/openactive-integration-tests/test/features/cancellation/customer-requested-cancellation/implemented/atomic-cancel-test.js
@@ -3,6 +3,7 @@ const { FeatureHelper } = require('../../../../helpers/feature-helper');
 const { FlowStageRecipes, FlowStageUtils, CancelOrderFlowStage } = require('../../../../helpers/flow-stages');
 const { AssertOpportunityCapacityFlowStage } = require('../../../../helpers/flow-stages/assert-opportunity-capacity');
 const { itShouldReturnAnOpenBookingError } = require('../../../../shared-behaviours/errors');
+const { ListenerItemExpectationRecipes } = require('../../../../helpers/listener-item-expectations');
 
 const { IMPLEMENTED_FEATURES } = global;
 
@@ -51,21 +52,26 @@ function (configuration, orderItemCriteriaList, featureIsImplemented, logger, de
   });
 
   // ### Cancel 1st Order Item which is cancellable
-  const cancelCancellableOrderItem = FlowStageRecipes.runs.customerCancel.successfulCancelAssertOrderUpdateAndCapacity(cancelNotCancellableOrderItems.getLastStage(), defaultFlowStageParams, {
-    cancelArgs: {
-      getOrderItemIdArray: CancelOrderFlowStage.getOrderItemIdsByPositionFromBookStages(bookRecipe.firstStage, [0]),
-      testName: 'Cancel Order for cancellable item',
+  const cancelCancellableOrderItem = FlowStageRecipes.runs.customerCancel.successfulCancelAssertOrderUpdateAndCapacity(
+    cancelNotCancellableOrderItems.getLastStage(),
+    defaultFlowStageParams,
+    {
+      cancelArgs: {
+        getOrderItemIdArray: CancelOrderFlowStage.getOrderItemIdsByPositionFromBookStages(bookRecipe.firstStage, [0]),
+        testName: 'Cancel Order for cancellable item',
+      },
+      assertOpportunityCapacityArgs: {
+        orderItemCriteriaList,
+        // Opportunity capacity should have incremented for the Opportunity at Order Item position 0
+        getInput: () => ({
+          opportunityFeedExtractResponses: bookRecipe.getAssertOpportunityCapacityAfterBook().getOutput().opportunityFeedExtractResponses,
+          orderItems: fetchOpportunities.getOutput().orderItems,
+        }),
+        getOpportunityExpectedCapacity: AssertOpportunityCapacityFlowStage.getOpportunityCapacityIncrementedForOrderItemPositions([0]),
+      },
+      listenerItemExpectations: [ListenerItemExpectationRecipes.nonConfirmedOrderItems(1)],
     },
-    assertOpportunityCapacityArgs: {
-      orderItemCriteriaList,
-      // Opportunity capacity should have incremented for the Opportunity at Order Item position 0
-      getInput: () => ({
-        opportunityFeedExtractResponses: bookRecipe.getAssertOpportunityCapacityAfterBook().getOutput().opportunityFeedExtractResponses,
-        orderItems: fetchOpportunities.getOutput().orderItems,
-      }),
-      getOpportunityExpectedCapacity: AssertOpportunityCapacityFlowStage.getOpportunityCapacityIncrementedForOrderItemPositions([0]),
-    },
-  });
+  );
 
   // ## Set up tests
   FlowStageUtils.describeRunAndCheckIsSuccessfulAndValid(fetchOpportunities);

--- a/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
+++ b/packages/openactive-integration-tests/test/helpers/flow-stages/flow-stage-recipes.js
@@ -618,9 +618,12 @@ const FlowStageRecipes = {
        * @param {object} args
        * @param {import('utility-types').Optional<ConstructorParameters<typeof CancelOrderFlowStage>[0], 'prerequisite' | 'requestHelper' | 'uuid'>} args.cancelArgs
        * @param {import('utility-types').Optional<ConstructorParameters<typeof AssertOpportunityCapacityFlowStage>[0], 'prerequisite' | 'requestHelper' | 'logger' | 'nameOfPreviousStage' | 'orderItemCriteriaList'>} args.assertOpportunityCapacityArgs
+       * @param {import('../listener-item-expectations').ListenerItemExpectation[]} args.listenerItemExpectations
        */
       successfulCancelAssertOrderUpdateAndCapacity(prerequisite, defaultFlowStageParams, {
-        cancelArgs, assertOpportunityCapacityArgs,
+        cancelArgs,
+        assertOpportunityCapacityArgs,
+        listenerItemExpectations,
       }) {
         const cancelTestName = cancelArgs.testName ?? 'Cancel';
         const [cancel, orderFeedUpdate] = OrderFeedUpdateFlowStageUtils.wrap({
@@ -633,6 +636,9 @@ const FlowStageRecipes = {
             ...defaultFlowStageParams,
             prerequisite,
             testName: `Orders Feed (after ${cancelTestName})`,
+            /* This allows us to support Booking Systems which update OrderItem
+            statuses one at a time, rather than all at once. */
+            listenerItemExpectations,
           },
         });
         const assertOpportunityCapacityAfterCancel = new AssertOpportunityCapacityFlowStage({


### PR DESCRIPTION
Implements #698 for customer-requested cancellations

## QA

I tested this against a booking system which is not yet stable, but was able to gain confidence that the feature works as expected.

These screenshots demonstrate some of this. They are a side-by-side comparison of the results for the `book-and-cancel` test. The LHS includes the changes and the RHS does not:

**Single mode**: 
![Screenshot 2024-11-01 at 11 31 04](https://github.com/user-attachments/assets/725cba9f-df2f-4d00-b558-b01e8ca64cd9)

Here, the booking system failed to produce the CustomerCancelled order feed change in the LHS test, but this lead to it failing at the order feed download step, as it could never be found. Whereas, in the RHS test, Test Suite passes the order feed download step but then later fails when asserting about orderItemStatuses

**Multiple mode**: 
![Screenshot 2024-11-01 at 11 32 04](https://github.com/user-attachments/assets/846c9984-5d83-4a50-bf3c-ea2842930a58)

Here, the booking system succeeded in producing the CustomerCancelled order feed change, and so the LHS test passed (except an unrelated validation issue), whereas the RHS did not, because Broker latched onto an irrelevant order feed update (this booking system is one that produces such updates)