### PR TITLE
Feed Snapshot Checker: Compile all errors into a resulting data format

### DIFF
--- a/packages/openactive-feed-snapshot-validator/src/app.js
+++ b/packages/openactive-feed-snapshot-validator/src/app.js
@@ -41,7 +41,7 @@ const MAX_ERRORS_PER_CHECK = 20;
 const RpdeItem = z.object({
   kind: z.string(),
   state: z.enum(['updated', 'deleted']),
-  id: z.string(),
+  id: z.union([z.number(), z.string()]),
   modified: z.union([z.number(), z.string()]),
   data: z.string().optional(),
 });


### PR DESCRIPTION
## QA

What the results look like when there are no RPDE errors:

![Screenshot 2025-02-25 at 12 44 02](https://github.com/user-attachments/assets/1d2312a1-8382-4a4f-8eec-54254d3352b9)
![Screenshot 2025-02-25 at 12 44 13](https://github.com/user-attachments/assets/48e41491-6fb9-43f2-bd66-4b6363d96e62)
